### PR TITLE
Fix some request/response types

### DIFF
--- a/api.go
+++ b/api.go
@@ -438,11 +438,11 @@ type GetOrderResponse struct {
 	// taken place but the order is not filled yet.<br>
 	// <code>COMPLETE</code> The order is no longer active. It has been settled
 	// or has been cancelled.
-	State string `json:"state"`
+	State OrderState `json:"state"`
 
 	// <code>BID</code> bid (buy) limit order.<br>
 	// <code>ASK</code> ask (sell) limit order.
-	Type string `json:"type"`
+	Type OrderType `json:"type"`
 }
 
 // GetOrder makes a call to GET /api/1/orders/{id}.
@@ -726,7 +726,7 @@ type ListTradesRequest struct {
 
 	// Fetch trades executed after this time, specified as a Unix timestamp in
 	// milliseconds.
-	Since int64 `json:"since" url:"since"`
+	Since Time `json:"since" url:"since"`
 }
 
 // ListTradesResponse is the response struct for ListTrades.
@@ -813,7 +813,7 @@ type ListUserTradesRequest struct {
 	Limit int64 `json:"limit" url:"limit"`
 
 	// Filter to trades on or after this timestamp.
-	Since int64 `json:"since" url:"since"`
+	Since Time `json:"since" url:"since"`
 }
 
 // ListUserTradesResponse is the response struct for ListUserTrades.

--- a/examples/readonly/main.go
+++ b/examples/readonly/main.go
@@ -57,7 +57,7 @@ func main() {
 	{
 		req := luno.ListTradesRequest{
 			Pair:  "XBTZAR",
-			Since: time.Now().Add(-24*time.Hour).UnixNano() / 1e6,
+			Since: luno.Time(time.Now().Add(-24 * time.Hour)),
 		}
 		res, err := cl.ListTrades(ctx, &req)
 		if err != nil {

--- a/time.go
+++ b/time.go
@@ -12,6 +12,10 @@ func (t *Time) UnmarshalJSON(b []byte) error {
 	if err != nil {
 		return err
 	}
+	if i == 0 {
+		*t = Time{}
+		return nil
+	}
 	*t = Time(time.Unix(0, i*1e6))
 	return nil
 }

--- a/types.go
+++ b/types.go
@@ -40,11 +40,11 @@ type Order struct {
 	// taken place but the order is not filled yet.<br>
 	// <code>COMPLETE</code> The order is no longer active. It has been settled
 	// or has been cancelled.
-	State string `json:"state"`
+	State OrderState `json:"state"`
 
 	// <code>BID</code> bid (buy) limit order.<br>
 	// <code>ASK</code> ask (sell) limit order.
-	Type string `json:"type"`
+	Type OrderType `json:"type"`
 }
 
 type OrderBookEntry struct {
@@ -55,8 +55,8 @@ type OrderBookEntry struct {
 type OrderState string
 
 const (
-	OrderStatePending  OrderState = "PENDING"
 	OrderStateComplete OrderState = "COMPLETE"
+	OrderStatePending  OrderState = "PENDING"
 )
 
 type OrderType string
@@ -98,7 +98,7 @@ type Trade struct {
 	Pair       string          `json:"pair"`
 	Price      decimal.Decimal `json:"price"`
 	Timestamp  Time            `json:"timestamp"`
-	Type       string          `json:"type"`
+	Type       OrderType       `json:"type"`
 	Volume     decimal.Decimal `json:"volume"`
 }
 


### PR DESCRIPTION
- `Order.State` and `GetOrderResponse.State`'s type changed to `OrderState`
- `Order.Type` and `GetOrderResponse.Type`'s type changed to `OrderType`
- `Since` parameters changed from `int64`s to `Time`s