### PR TITLE
added a new custom http client function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,6 @@
+module github.com/mychell/luno-go
+
+require (
+	github.com/luno/luno-go v0.0.4
+	golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/luno/luno-go v0.0.4 h1:nUifEftpgRViRvHqOwDFORTEY1G3q5CXLpf9ePmydjo=
+github.com/luno/luno-go v0.0.4/go.mod h1:CRIGxDeqYci6skFJy5434yO3uCa5MaHPoxrtgh2DzF8=
+golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3 h1:ulvT7fqt0yHWzpJwI57MezWnYDVpCAYBVuYst/L+fAY=
+golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/luno.go
+++ b/luno.go
@@ -51,6 +51,15 @@ func NewClient() *Client {
 	}
 }
 
+// NewWithCustomHTTPClient creates a new Luno API client with the default base URL using your own custom http client.
+// You can easily use this to restrict your API calls to only whitelisted ip addresses
+func NewWithCustomHTTPClient(client *http.Client) *Client {
+	return &Client{
+		httpClient: client,
+		baseURL:    defaultBaseURL,
+	}
+}
+
 // SetAuth provides the client with an API key and secret.
 func (cl *Client) SetAuth(apiKeyID, apiKeySecret string) error {
 	if apiKeyID == "" || apiKeySecret == "" {

--- a/version.go
+++ b/version.go
@@ -1,5 +1,6 @@
 package luno
 
-const Version = "0.0.4"
+// Version package version
+const Version = "0.0.5"
 
 // vi: ft=go


### PR DESCRIPTION
I added a function to allow initializing a new client with your own custom HTTP client as a parameter. 

This is useful in cases whereby, you have an API key and secret tied to particular IP addresses.