### PR TITLE
Updated the README to show a working example for the latest version (Closes #52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ import (
   "log"
   "context"
   "time"
-  luno "github.com/luno/luno-go"
+  "github.com/luno/luno-go"
 )
 
 func main() {

--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ func main() {
 }
 ```
 
-Remember to substitute `<API_KEY_ID>` and `<API_KEY_SECRET>` for your own Id and Secret.
+Remember to substitute `<id>` and `<secret>` for your own Id and Secret.
 
 We recommend using environment variables rather than including your credentials in plaintext. In Bash you do so as follows:
 ```
-$ export LUNO_API_ID="<API_KEY_ID>"
-$ export LUNO_API_SECRET="<API_KEY_SECRET>"
+$ export LUNO_API_ID="<id>"
+$ export LUNO_API_SECRET="<secret>"
 ```
 
 And then access them in Go like so:

--- a/README.md
+++ b/README.md
@@ -27,47 +27,45 @@ A full working example of this library in action.
 ```go
 package main
 
-import luno "github.com/luno/luno-go"
 import (
   "log"
   "context"
   "time"
+  luno "github.com/luno/luno-go"
 )
 
-lunoClient := luno.NewClient()
-lunoClient.SetAuth("<API_KEY_ID>", "<API_KEY_SECRET>")
+func main() {
+  lunoClient := luno.NewClient()
+  lunoClient.SetAuth("<id>", "<secret>")
 
-req := luno.GetOrderBookRequest{Pair: "XBTZAR"}
-ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(10 * time.Second))
-defer cancel()
+  req := luno.GetOrderBookRequest{Pair: "XBTZAR"}
+  ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(10 * time.Second))
+  defer cancel()
 
-res, err := lunoClient.GetOrderBook(ctx, &req)
-if err != nil {
-  log.Fatal(err)
+  res, err := lunoClient.GetOrderBook(ctx, &req)
+  if err != nil {
+    log.Fatal(err)
+  }
+  log.Println(res)
 }
-log.Println(res)
 ```
 
 Remember to substitute `<API_KEY_ID>` and `<API_KEY_SECRET>` for your own Id and Secret.
 
-It is also recommended to set these as environment variables rather than include them in plaintext. You can do this on `BASH` with:
-
+We recommend using environment variables rather than including your credentials in plaintext. In Bash you do so as follows:
 ```
-$ set LUNO_API_ID="<API_KEY_ID>"
-$ set LUNO_API_SECRET="<API_KEY_SECRET>"
+$ export LUNO_API_ID="<API_KEY_ID>"
+$ export LUNO_API_SECRET="<API_KEY_SECRET>"
 ```
 
 And then access them in Go like so:
 
 ```go
-
 import "os"
 
 var API_KEY_ID string = os.Getenv("LUNO_API_ID")
 var API_KEY_SECRET string = os.Getenv("LUNO_API_SECRET")
-
 ```
-
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ And then access them in Go like so:
 
 import "os"
 
-var API_KEY_ID string = os.Getenv("LUNO_KEY_ID")
-var API_KEY_SECRET string = os.Getenv("LUNO_KEY_SECRET")
+var API_KEY_ID string = os.Getenv("LUNO_API_ID")
+var API_KEY_SECRET string = os.Getenv("LUNO_API_SECRET")
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@
 
 This Go package provides a wrapper for the [Luno API](https://www.luno.com/api).
 
-### Documentation
+## Documentation
 
 Please visit [godoc.org](https://godoc.org/github.com/luno/luno-go) for the full
 package documentation.
 
-### Authentication
+## Authentication
 
 Please visit the [Settings](https://www.luno.com/wallet/settings/api_keys) page
 to generate an API key.
 
-### Installation
+## Installation
 
 ```
 go get github.com/luno/luno-go
@@ -67,6 +67,6 @@ var API_KEY_ID string = os.Getenv("LUNO_API_ID")
 var API_KEY_SECRET string = os.Getenv("LUNO_API_SECRET")
 ```
 
-### License
+## License
 
 [MIT](https://github.com/luno/luno-go/blob/master/LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -9,32 +9,65 @@ This Go package provides a wrapper for the [Luno API](https://www.luno.com/api).
 Please visit [godoc.org](https://godoc.org/github.com/luno/luno-go) for the full
 package documentation.
 
+### Authentication
+
+Please visit the [Settings](https://www.luno.com/wallet/settings/api_keys) page
+to generate an API key.
+
 ### Installation
 
 ```
 go get github.com/luno/luno-go
 ```
 
-### Authentication
-
-Please visit the [Settings](https://www.luno.com/wallet/settings/api_keys) page
-to generate an API key.
-
 ### Example usage
 
+A full working example of this library in action.
+
 ```go
+package main
+
 import luno "github.com/luno/luno-go"
+import (
+  "log"
+  "context"
+  "time"
+)
 
 lunoClient := luno.NewClient()
-lunoClient.SetAuth("api_key_id", "api_key_secret")
+lunoClient.SetAuth("<API_KEY_ID>", "<API_KEY_SECRET>")
 
 req := luno.GetOrderBookRequest{Pair: "XBTZAR"}
-res, err := lunoClient.GetOrderBook(&req)
+ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(10 * time.Second))
+defer cancel()
+
+res, err := lunoClient.GetOrderBook(ctx, &req)
 if err != nil {
   log.Fatal(err)
 }
 log.Println(res)
 ```
+
+Remember to substitute `<API_KEY_ID>` and `<API_KEY_SECRET>` for your own Id and Secret.
+
+It is also recommended to set these as environment variables rather than include them in plaintext. You can do this on `BASH` with:
+
+```
+$ set LUNO_API_ID="<API_KEY_ID>"
+$ set LUNO_API_SECRET="<API_KEY_SECRET>"
+```
+
+And then access them in Go like so:
+
+```go
+
+import "os"
+
+var API_KEY_ID string = os.Getenv("LUNO_KEY_ID")
+var API_KEY_SECRET string = os.Getenv("LUNO_KEY_SECRET")
+
+```
+
 
 ### License
 


### PR DESCRIPTION
The README hadn't been updated for over a year. 

Hence, the example provided does not actually work with the most recent version of the library.

I updated the README to show a full working example compatible with the most recent version of the library, which requires `Context` to be passed to the methods of `Client`.

