### PR TITLE
Fix the conversion of []string params

### DIFF
--- a/api.go
+++ b/api.go
@@ -687,6 +687,8 @@ func (cl *Client) GetTicker(ctx context.Context, req *GetTickerRequest) (*GetTic
 
 // GetTickersRequest is the request struct for GetTickers.
 type GetTickersRequest struct {
+	// Currency pairs
+	Pair []string `json:"pair" url:"pair"`
 }
 
 // GetTickersResponse is the response struct for GetTickers.

--- a/util.go
+++ b/util.go
@@ -30,19 +30,18 @@ func makeURLValues(v interface{}) url.Values {
 		}
 
 		k := fieldValue.Kind()
-		var s string
 		ss := make([]string, 0)
 		switch k {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32,
 			reflect.Int64:
-			s = strconv.FormatInt(fieldValue.Int(), 10)
+			ss = append(ss, strconv.FormatInt(fieldValue.Int(), 10))
 		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32,
 			reflect.Uint64:
-			s = strconv.FormatUint(fieldValue.Uint(), 10)
+			ss = append(ss, strconv.FormatUint(fieldValue.Uint(), 10))
 		case reflect.Float32:
-			s = strconv.FormatFloat(fieldValue.Float(), 'f', 4, 32)
+			ss = append(ss, strconv.FormatFloat(fieldValue.Float(), 'f', 4, 32))
 		case reflect.Float64:
-			s = strconv.FormatFloat(fieldValue.Float(), 'f', 4, 64)
+			ss = append(ss, strconv.FormatFloat(fieldValue.Float(), 'f', 4, 64))
 		case reflect.Slice:
 			 if field.Type.Elem().Kind() == reflect.String {
 				for i := 0; i < fieldValue.Len(); i++ {
@@ -50,16 +49,12 @@ func makeURLValues(v interface{}) url.Values {
 				}
 			}
 		case reflect.String:
-			s = fieldValue.String()
+			ss = append(ss, fieldValue.String())
 		case reflect.Bool:
-			s = fmt.Sprintf("%v", fieldValue.Bool())
+			ss = append(ss, fmt.Sprintf("%v", fieldValue.Bool()))
 		}
-		if len(ss) > 0 {
-			for _, str := range ss {
-				values.Add(urlTag, str)
-			}
-		} else {
-			values.Set(urlTag, s)
+		for _, str := range ss {
+			values.Add(urlTag, str)
 		}
 	}
 

--- a/util.go
+++ b/util.go
@@ -31,6 +31,7 @@ func makeURLValues(v interface{}) url.Values {
 
 		k := fieldValue.Kind()
 		var s string
+		ss := make([]string, 0)
 		switch k {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32,
 			reflect.Int64:
@@ -43,15 +44,23 @@ func makeURLValues(v interface{}) url.Values {
 		case reflect.Float64:
 			s = strconv.FormatFloat(fieldValue.Float(), 'f', 4, 64)
 		case reflect.Slice:
-			if field.Type.Elem().Kind() == reflect.Uint8 {
-				s = string(fieldValue.Bytes())
+			 if field.Type.Elem().Kind() == reflect.String {
+				for i := 0; i < fieldValue.Len(); i++ {
+					ss = append(ss, fieldValue.Index(i).String())
+				}
 			}
 		case reflect.String:
 			s = fieldValue.String()
 		case reflect.Bool:
 			s = fmt.Sprintf("%v", fieldValue.Bool())
 		}
-		values.Set(urlTag, s)
+		if len(ss) > 0 {
+			for _, str := range ss {
+				values.Add(urlTag, str)
+			}
+		} else {
+			values.Set(urlTag, s)
+		}
 	}
 
 	return values

--- a/util_internal_test.go
+++ b/util_internal_test.go
@@ -18,7 +18,7 @@ func TestMakeURLValues(t *testing.T) {
 		F32 float32         `url:"f32"`
 		F64 float64         `url:"f64"`
 		B   bool            `url:"b"`
-		ABy []byte          `url:"aby"`
+		ASt []string        `url:"ast"`
 		TS  S               `url:"ts"`
 		Amt decimal.Decimal `url:"amt"`
 		T   Time            `url:"t"` // implements QueryValuer
@@ -38,12 +38,12 @@ func TestMakeURLValues(t *testing.T) {
 				F32: 42.42,
 				F64: 42.42,
 				B:   true,
-				ABy: []byte("foo"),
+				ASt: []string{"foo", "bar"},
 				TS:  S("foo"),
 				Amt: decimal.NewFromFloat64(2.1, 1),
 				T:   Time(time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)),
 			},
-			expected: "aby=foo&amt=2.1&b=true&f32=42.4200&f64=42.4200&i=42&i64=42&s=foo&t=1514764800000&ts=foo",
+			expected: "amt=2.1&ast=foo&ast=bar&b=true&f32=42.4200&f64=42.4200&i=42&i64=42&s=foo&t=1514764800000&ts=foo",
 		},
 		{
 			name: "zero time",
@@ -54,12 +54,12 @@ func TestMakeURLValues(t *testing.T) {
 				F32: 42.42,
 				F64: 42.42,
 				B:   true,
-				ABy: []byte("foo"),
+				ASt: []string{"foo", "bar"},
 				TS:  S("foo"),
 				Amt: decimal.NewFromFloat64(0.1, 1),
 				T:   Time(time.Time{}),
 			},
-			expected: "aby=foo&amt=0.1&b=true&f32=42.4200&f64=42.4200&i=42&i64=42&s=foo&t=&ts=foo",
+			expected: "amt=0.1&ast=foo&ast=bar&b=true&f32=42.4200&f64=42.4200&i=42&i64=42&s=foo&t=&ts=foo",
 		},
 		{
 			name:"valid amount",
@@ -70,12 +70,12 @@ func TestMakeURLValues(t *testing.T) {
 				F32: 42.42,
 				F64: 42.42,
 				B:   true,
-				ABy: []byte("foo"),
+				ASt: []string{"foo", "bar"},
 				TS:  S("foo"),
 				Amt: decimal.NewFromFloat64(0.0001, 10),
 				T:   Time(time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)),
 			},
-			expected:"aby=foo&amt=0.0001000000&b=true&f32=42.4200&f64=42.4200&i=42&i64=42&s=foo&t=1514764800000&ts=foo",
+			expected:"amt=0.0001000000&ast=foo&ast=bar&b=true&f32=42.4200&f64=42.4200&i=42&i64=42&s=foo&t=1514764800000&ts=foo",
 		},
 	}
 


### PR DESCRIPTION
The endpoints `GetTickers` (`/api/1/tickers`) and `GetBalances` (`/api/1/balance`) have []string parameters, which are not converted correctly and the empty string is passed to the query instead.

This fixes that, and adds the `pair` param to `GetTickers`, to be consistent with the API doc.