### PR TITLE
Update float64() implementation to better handle decimal precision

### DIFF
--- a/decimal/decimal.go
+++ b/decimal/decimal.go
@@ -42,13 +42,7 @@ func NewFromString(s string) (Decimal, error) {
 	if strings.IndexByte(s, 'e') > -1 {
 		return Decimal{}, ErrUnsupportedDecimalNotation
 	}
-
-	// If we have a decimal point...we will trim out redundant zeros, so we
-	// don't overflow float64 decimal points unnecessarily
-	if strings.IndexByte(s, '.') > -1 {
-		s = strings.TrimRight(strings.TrimRight(s, "0"), ".")
-	}
-
+	
 	scale := getScale(s)
 	s = strings.Replace(s, ".", "", 1)
 	i, ok := new(big.Int).SetString(s, 10)

--- a/decimal/decimal.go
+++ b/decimal/decimal.go
@@ -42,7 +42,7 @@ func NewFromString(s string) (Decimal, error) {
 	if strings.IndexByte(s, 'e') > -1 {
 		return Decimal{}, ErrUnsupportedDecimalNotation
 	}
-	
+
 	scale := getScale(s)
 	s = strings.Replace(s, ".", "", 1)
 	i, ok := new(big.Int).SetString(s, 10)
@@ -111,8 +111,6 @@ func (d Decimal) Float64() float64 {
 	scale := big.NewInt(int64(d.scale))
 	scale.Exp(big.NewInt(10), scale, nil)
 
-	fmt.Println("scale")
-	fmt.Println(scale)
 	r := new(big.Rat)
 	r.SetFrac(bigIntDefault(d.i), scale)
 

--- a/decimal/decimal_test.go
+++ b/decimal/decimal_test.go
@@ -7,6 +7,38 @@ import (
 	"github.com/luno/luno-go/decimal"
 )
 
+func TestFloat64(t *testing.T) {
+	type testCase struct {
+		a   string
+		b   string
+		exp float64
+	}
+
+	testCases := []testCase{
+		testCase{
+			a:   "0.17800000",
+			b:   "6750.00000000",
+			exp: 1201.5,
+		},
+		testCase{
+			a:   "0.178000001",
+			b:   "6750.000000001",
+			exp: 1201.500006750178,
+		},
+	}
+
+	for _, test := range testCases {
+		a, _ := decimal.NewFromString(test.a)
+		b, _ := decimal.NewFromString(test.b)
+
+		act := a.Mul(b).Float64()
+
+		if act != test.exp {
+			t.Errorf("Expected %s * %s to stringify as %g, got %g", test.a, test.b, test.exp, act)
+		}
+	}
+}
+
 func TestNewFromInt64(t *testing.T) {
 	type testCase struct {
 		i   int64


### PR DESCRIPTION
Before:

```
d1, _ := decimal.NewFromString("0.17800000")
d2, _ := decimal.NewFromString("6750.00000000")
fmt.Println(d1.Mul(d2).Float64())
-643.1744073709551
```

After:
```
d1, _ := decimal.NewFromString("0.17800000")
d2, _ := decimal.NewFromString("6750.00000000")
fmt.Println(d1.Mul(d2).Float64())
1201.5
```