### PR TITLE
Adding ID to OrderBookEntry

### DIFF
--- a/types.go
+++ b/types.go
@@ -206,6 +206,8 @@ type Order struct {
 }
 
 type OrderBookEntry struct {
+	Id string `json:"id"`
+
 	// Limit price at which orders are trading at
 	Price decimal.Decimal `json:"price"`
 


### PR DESCRIPTION
Please refer to the API specification: 
https://www.luno.com/en/developers/api#tag/Streaming-API

Scroll down to where this is mentioned:
```The server will then send the current order book in the following format:```

The API shows that bids and asks are accompanied by an ID. The ID is indeed included in the streamed data, but the client does not make use of the field.

This change is to make the ID field available to client users.

