### PR TITLE
Adding missing maker and taker order ID fields to TradeUpdate struct

### DIFF
--- a/streaming/messages.go
+++ b/streaming/messages.go
@@ -19,9 +19,11 @@ type orderBook struct {
 }
 
 type TradeUpdate struct {
-	Base    decimal.Decimal `json:"base,string"`
-	Counter decimal.Decimal `json:"counter,string"`
-	OrderID string          `json:"order_id"`
+	Base         decimal.Decimal `json:"base,string"`
+	Counter      decimal.Decimal `json:"counter,string"`
+	MakerOrderID string          `json:"maker_order_id"`
+	TakerOrderID string          `json:"taker_order_id"`
+	OrderID      string          `json:"order_id"`
 }
 
 type CreateUpdate struct {

--- a/streaming/messages.go
+++ b/streaming/messages.go
@@ -27,7 +27,7 @@ type TradeUpdate struct {
 	MakerOrderID string `json:"maker_order_id"`
 	// TakeOrderID is the ID of the order that matched against a pre-existing order.
 	TakerOrderID string `json:"taker_order_id"`
-	// OrderID is deprecated.
+	// Deprecated: Use MakerOrderID and TakerOrderID.
 	OrderID string `json:"order_id"`
 }
 

--- a/streaming/messages.go
+++ b/streaming/messages.go
@@ -19,11 +19,16 @@ type orderBook struct {
 }
 
 type TradeUpdate struct {
-	Base         decimal.Decimal `json:"base,string"`
-	Counter      decimal.Decimal `json:"counter,string"`
-	MakerOrderID string          `json:"maker_order_id"`
-	TakerOrderID string          `json:"taker_order_id"`
-	OrderID      string          `json:"order_id"`
+	// Base is the volume of the base currency that was filled.
+	Base decimal.Decimal `json:"base,string"`
+	// Counter is the price at which the order filled.
+	Counter decimal.Decimal `json:"counter,string"`
+	// MakerOrderID is the ID of the pre-existing order in the order book that was matched.
+	MakerOrderID string `json:"maker_order_id"`
+	// TakeOrderID is the ID of the order that matched against a pre-existing order.
+	TakerOrderID string `json:"taker_order_id"`
+	// OrderID is deprecated.
+	OrderID string `json:"order_id"`
 }
 
 type CreateUpdate struct {


### PR DESCRIPTION
Here is some raw data returned by the webhook.  Notice that the maker and taker order ID is present in the json object, but the fields are missing in the API's `TradeUpdate` struct.  This PR makes these two fields available to client applications.

```
{
  "sequence": "1441552179",
  "trade_updates": [
    {
      "base": "0.00083400",
      "counter": "443.0233020000000000",
      "maker_order_id": "BXJ7CE79BHRPTVS",
      "taker_order_id": "BXCMS3RWN3FJW84",
      "order_id": "BXJ7CE79BHRPTVS"
    }
  ],
  "create_update": {
    "order_id": "BXCMS3RWN3FJW84",
    "type": "ASK",
    "price": "531203.00000000",
    "volume": "0.00105200"
  },
  "delete_update": null,
  "status_update": null,
  "timestamp": 1684657400681
}
```