### PR TITLE
Add sequence to trade updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,11 @@ import (
   "context"
   "time"
   "github.com/luno/luno-go"
-  "golang.org/x/time/rate"
 )
 
 func main() {
-  rateLimiter := rate.NewLimiter(rate.Every(time.Minute/300), 1)
   lunoClient := luno.NewClient()
   lunoClient.SetAuth("<id>", "<secret>")
-  lunoClient.SetRateLimiter(rateLimiter)
 
   req := luno.GetOrderBookRequest{Pair: "XBTZAR"}
   ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(10 * time.Second))

--- a/README.md
+++ b/README.md
@@ -32,11 +32,14 @@ import (
   "context"
   "time"
   "github.com/luno/luno-go"
+  "golang.org/x/time/rate"
 )
 
 func main() {
+  rateLimiter := rate.NewLimiter(rate.Every(time.Minute/300), 1)
   lunoClient := luno.NewClient()
   lunoClient.SetAuth("<id>", "<secret>")
+  lunoClient.SetRateLimiter(rateLimiter)
 
   req := luno.GetOrderBookRequest{Pair: "XBTZAR"}
   ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(10 * time.Second))

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/luno/luno-go
 
 go 1.20
 
-require github.com/gorilla/websocket v1.5.0
+require (
+	github.com/gorilla/websocket v1.5.0
+	golang.org/x/time v0.3.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+golang.org/x/time v0.3.0 h1:rg5rLMjNzMS1RkNLzCG38eapWhnYLFYXDXj2gOlr8j4=
+golang.org/x/time v0.3.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/luno.go
+++ b/luno.go
@@ -16,14 +16,14 @@ import (
 	"time"
 )
 
-type limiter interface {
+type Limiter interface {
 	Wait(context.Context) error
 }
 
 // Client is a Luno API client.
 type Client struct {
 	httpClient   *http.Client
-	rateLimiter  limiter
+	rateLimiter  Limiter
 	baseURL      string
 	apiKeyID     string
 	apiKeySecret string
@@ -59,7 +59,7 @@ func (cl *Client) SetHTTPClient(httpClient *http.Client) {
 
 // SetRateLimiter sets the rate limiter that will be used to throttle calls
 // made through the client.
-func (cl *Client) SetRateLimiter(rateLimiter limiter) {
+func (cl *Client) SetRateLimiter(rateLimiter Limiter) {
 	cl.rateLimiter = rateLimiter
 }
 

--- a/luno.go
+++ b/luno.go
@@ -37,7 +37,12 @@ const (
 	defaultTimeout = 10 * time.Second
 	// Rate limiting parameters:
 	// Refer to https://www.luno.com/en/developers/api#tag/Rate-Limiting
-	defaultRate  = time.Minute / 300
+	// The default configuration allows for a burst of 1 request every 200ms
+	// which aggregates to 300 requests per minute.
+	//
+	// defaultRate specifies the rate at which requests are allowed.
+	defaultRate = time.Minute / 300
+	// defaultBurst specifies the maximum number of requests allowed in a burst.
 	defaultBurst = 1
 )
 

--- a/luno.go
+++ b/luno.go
@@ -35,8 +35,10 @@ type Client struct {
 const (
 	defaultBaseURL = "https://api.luno.com"
 	defaultTimeout = 10 * time.Second
-	defaultRate    = time.Minute / 300
-	defaultBurst   = 1
+	// Rate limiting parameters:
+	// Refer to https://www.luno.com/en/developers/api#tag/Rate-Limiting
+	defaultRate  = time.Minute / 300
+	defaultBurst = 1
 )
 
 // NewClient creates a new Luno API client with the default base URL.

--- a/streaming/messages.go
+++ b/streaming/messages.go
@@ -19,6 +19,9 @@ type orderBook struct {
 }
 
 type TradeUpdate struct {
+	// Sequence is the monotonically increasing sequence number of the trade
+	// for the market in question.
+	Sequence int64 `json:"sequence"`
 	// Base is the volume of the base currency that was filled.
 	Base decimal.Decimal `json:"base,string"`
 	// Counter is the price at which the order filled.
@@ -27,7 +30,7 @@ type TradeUpdate struct {
 	MakerOrderID string `json:"maker_order_id"`
 	// TakeOrderID is the ID of the order that matched against a pre-existing order.
 	TakerOrderID string `json:"taker_order_id"`
-	// Deprecated: Use MakerOrderID and TakerOrderID.
+	// Deprecated: Use MakerOrderID.
 	OrderID string `json:"order_id"`
 }
 

--- a/streaming/messages.go
+++ b/streaming/messages.go
@@ -19,9 +19,16 @@ type orderBook struct {
 }
 
 type TradeUpdate struct {
-	Base    decimal.Decimal `json:"base,string"`
+	// Base is the volume of the base currency that was filled.
+	Base decimal.Decimal `json:"base,string"`
+	// Counter is the price at which the order filled.
 	Counter decimal.Decimal `json:"counter,string"`
-	OrderID string          `json:"order_id"`
+	// MakerOrderID is the ID of the pre-existing order in the order book that was matched.
+	MakerOrderID string `json:"maker_order_id"`
+	// TakeOrderID is the ID of the order that matched against a pre-existing order.
+	TakerOrderID string `json:"taker_order_id"`
+	// Deprecated: Use MakerOrderID and TakerOrderID.
+	OrderID string `json:"order_id"`
 }
 
 type CreateUpdate struct {

--- a/streaming/streaming.go
+++ b/streaming/streaming.go
@@ -353,11 +353,15 @@ func (c *Conn) processTrade(t TradeUpdate) error {
 	}
 
 	c.lastTrade = TradeUpdate{
-		Base:    t.Base,
-		Counter: t.Counter,
+		Sequence:     t.Sequence,
+		Base:         t.Base,
+		Counter:      t.Counter,
+		MakerOrderID: t.MakerOrderID,
+		TakerOrderID: t.TakerOrderID,
+		OrderID:      t.OrderID,
 	}
 
-	ok, err := decTrade(c.bids, t.OrderID, t.Base)
+	ok, err := decTrade(c.bids, t.MakerOrderID, t.Base)
 	if err != nil {
 		return err
 	}
@@ -365,7 +369,7 @@ func (c *Conn) processTrade(t TradeUpdate) error {
 		return nil
 	}
 
-	ok, err = decTrade(c.asks, t.OrderID, t.Base)
+	ok, err = decTrade(c.asks, t.MakerOrderID, t.Base)
 	if err != nil {
 		return err
 	}

--- a/streaming/streaming_internal_test.go
+++ b/streaming/streaming_internal_test.go
@@ -88,10 +88,20 @@ func TestReceivedUpdate(t *testing.T) {
 			args: args{
 				u: Update{Sequence: 2,
 					TradeUpdates: []*TradeUpdate{
-						{Base: decimal.NewFromFloat64(0.02, 2),
-							Counter: decimal.NewFromFloat64(0.002, 2), OrderID: "1"},
-						{Base: decimal.NewFromFloat64(0.01, 2),
-							Counter: decimal.NewFromFloat64(0.001, 2), OrderID: "1"},
+						{
+							Sequence:     1,
+							Base:         decimal.NewFromFloat64(0.02, 2),
+							Counter:      decimal.NewFromFloat64(0.002, 2),
+							MakerOrderID: "1",
+							TakerOrderID: "32",
+						},
+						{
+							Sequence:     2,
+							Base:         decimal.NewFromFloat64(0.01, 2),
+							Counter:      decimal.NewFromFloat64(0.001, 2),
+							MakerOrderID: "1",
+							TakerOrderID: "34",
+						},
 					},
 				},
 			},
@@ -99,9 +109,14 @@ func TestReceivedUpdate(t *testing.T) {
 				wantErr: false,
 				asks:    asksMap(),
 				bids: bidsMap(order{ID: "1", Price: decimal.NewFromFloat64(120.0, 1),
-					Volume: decimal.NewFromFloat64(0.08, 2)}),
-				lastTrade: TradeUpdate{Base: decimal.NewFromFloat64(0.01, 2),
-					Counter: decimal.NewFromFloat64(0.001, 2), OrderID: "1"},
+					Volume: decimal.NewFromFloat64(0.07, 2)}),
+				lastTrade: TradeUpdate{
+					Sequence:     2,
+					Base:         decimal.NewFromFloat64(0.01, 2),
+					Counter:      decimal.NewFromFloat64(0.001, 2),
+					MakerOrderID: "1",
+					TakerOrderID: "34"
+				},
 				seq:    2,
 				status: luno.StatusActive,
 			},
@@ -111,10 +126,20 @@ func TestReceivedUpdate(t *testing.T) {
 			args: args{
 				u: Update{Sequence: 2,
 					TradeUpdates: []*TradeUpdate{
-						{Base: decimal.NewFromFloat64(0.01, 2),
-							Counter: decimal.NewFromFloat64(0.001, 2), OrderID: "4"},
-						{Base: decimal.NewFromFloat64(0.01, 2),
-							Counter: decimal.NewFromFloat64(0.001, 2), OrderID: "3"},
+						{
+							Sequence:     1,
+							Base:         decimal.NewFromFloat64(0.01, 2),
+							Counter:      decimal.NewFromFloat64(0.001, 2),
+							MakerOrderID: "4",
+							TakerOrderID: "32",
+						},
+						{
+							Sequence:     2,
+							Base:         decimal.NewFromFloat64(0.01, 2),
+							Counter:      decimal.NewFromFloat64(0.001, 2),
+							MakerOrderID: "3",
+							TakerOrderID: "34",
+						},
 					},
 				},
 			},
@@ -124,8 +149,13 @@ func TestReceivedUpdate(t *testing.T) {
 					Volume: decimal.NewFromFloat64(0.99, 2)}),
 				bids: bidsMap(order{ID: "3", Price: decimal.NewFromFloat64(100.0, 1),
 					Volume: decimal.NewFromFloat64(0.99, 2)}),
-				lastTrade: TradeUpdate{Base: decimal.NewFromFloat64(0.01, 2),
-					Counter: decimal.NewFromFloat64(0.001, 2), OrderID: "3"},
+				lastTrade: TradeUpdate{
+					Sequence:     2,
+					Base:         decimal.NewFromFloat64(0.01, 2),
+					Counter:      decimal.NewFromFloat64(0.001, 2),
+					MakerOrderID: "3",
+					TakerOrderID: "34",
+				},
 				seq:    2,
 				status: luno.StatusActive,
 			},
@@ -135,20 +165,40 @@ func TestReceivedUpdate(t *testing.T) {
 			args: args{
 				u: Update{Sequence: 2,
 					TradeUpdates: []*TradeUpdate{
-						{Base: decimal.NewFromFloat64(0.5, 1),
-							Counter: decimal.NewFromFloat64(0.1, 2), OrderID: "2"},
-						{Base: decimal.NewFromFloat64(1, 1),
-							Counter: decimal.NewFromFloat64(1, 1), OrderID: "4"},
-						{Base: decimal.NewFromFloat64(0.1, 1),
-							Counter: decimal.NewFromFloat64(1, 1), OrderID: "6"},
+						{
+							Sequence:     1,
+							Base:         decimal.NewFromFloat64(0.5, 1),
+							Counter:      decimal.NewFromFloat64(0.1, 2),
+							MakerOrderID: "2",
+							TakerOrderID: "32",
+						},
+						{
+							Sequence:     2,
+							Base:         decimal.NewFromFloat64(1, 1),
+							Counter:      decimal.NewFromFloat64(1, 1),
+							MakerOrderID: "4",
+							TakerOrderID: "34",
+						},
+						{
+							Sequence:     3,
+							Base:         decimal.NewFromFloat64(0.1, 1),
+							Counter:      decimal.NewFromFloat64(1, 1),
+							MakerOrderID: "6",
+							TakerOrderID: "36",
+						},
 					},
 				},
 			},
 			expected: expected{
 				wantErr: false,
 				bids:    bidsMap(),
-				lastTrade: TradeUpdate{Base: decimal.NewFromFloat64(0.1, 1),
-					Counter: decimal.NewFromFloat64(1, 1), OrderID: "6"},
+				lastTrade: TradeUpdate{
+					Sequence:     3,
+					Base:         decimal.NewFromFloat64(0.1, 1),
+					Counter:      decimal.NewFromFloat64(1, 1),
+					MakerOrderID: "6",
+					TakerOrderID: "36",
+				},
 				seq:    2,
 				status: luno.StatusActive,
 			},
@@ -190,7 +240,8 @@ func TestReceivedCreate(t *testing.T) {
 					CreateUpdate: &CreateUpdate{OrderID: "8",
 						Price:  decimal.NewFromFloat64(6700.56, 2),
 						Type:   "ASKBID",
-						Volume: decimal.NewFromFloat64(0.01, 2)},
+						Volume: decimal.NewFromFloat64(0.01, 2),
+					},
 				}},
 			expected: expected{
 				wantErr: true,
@@ -203,7 +254,8 @@ func TestReceivedCreate(t *testing.T) {
 					CreateUpdate: &CreateUpdate{OrderID: "8",
 						Price:  decimal.NewFromFloat64(6700.56, 2),
 						Type:   "ASK",
-						Volume: decimal.NewFromFloat64(0.01, 2)},
+						Volume: decimal.NewFromFloat64(0.01, 2),
+					},
 				}},
 			expected: expected{
 				wantErr: false,
@@ -222,7 +274,8 @@ func TestReceivedCreate(t *testing.T) {
 					CreateUpdate: &CreateUpdate{OrderID: "7",
 						Price:  decimal.NewFromFloat64(6700.54, 2),
 						Type:   "BID",
-						Volume: decimal.NewFromFloat64(0.01, 2)},
+						Volume: decimal.NewFromFloat64(0.01, 2),
+					},
 				}},
 			expected: expected{
 				wantErr: false,
@@ -378,16 +431,16 @@ func existsInOtherMap(a, b map[string]order) bool {
 }
 
 func compareLastTrade(a, b TradeUpdate) bool {
-	if &a == &b {
-		return true
-	}
 	if a.Base.Cmp(b.Base) != 0 {
 		return false
 	}
+	a.Base = b.Base
 	if a.Counter.Cmp(b.Counter) != 0 {
 		return false
 	}
-	return true
+	a.Counter = b.Counter
+
+	return a == b
 }
 
 func validateResult(err error, t *testing.T, exp expected, c *Conn) {
@@ -396,6 +449,9 @@ func validateResult(err error, t *testing.T, exp expected, c *Conn) {
 	}
 	if !compareOrderMaps(exp.asks, c.asks) {
 		t.Errorf("Invalid asks. Expected:%v, got:%v", exp.asks, c.asks)
+	}
+	if !compareOrderMaps(exp.bids, c.bids) {
+		t.Errorf("Invalid bids. Expected:%v, got:%v", exp.bids, c.bids)
 	}
 	if !compareLastTrade(exp.lastTrade, c.lastTrade) {
 		t.Errorf("Invalid lastTrade. Expected:%v, got:%v", exp.lastTrade, c.lastTrade)

--- a/types.go
+++ b/types.go
@@ -206,6 +206,8 @@ type Order struct {
 }
 
 type OrderBookEntry struct {
+	Id string `json:"id"`
+
 	// Limit price at which orders are trading at
 	Price decimal.Decimal `json:"price"`
 


### PR DESCRIPTION
A change was recently made to the backend API server to include the trade sequence in the TradeUpdate struct.
This PR makes the corresponding change to the go SDK.
Tests have also been updated and corrected.