### PR TITLE
Add order id to flatten

### DIFF
--- a/streaming/streaming.go
+++ b/streaming/streaming.go
@@ -67,6 +67,7 @@ func flatten(m map[string]order, reverse bool) []luno.OrderBookEntry {
 	var ol []luno.OrderBookEntry
 	for _, o := range m {
 		ol = append(ol, luno.OrderBookEntry{
+			ID:     o.ID,
 			Price:  o.Price,
 			Volume: o.Volume,
 		})

--- a/streaming/streaming_internal_test.go
+++ b/streaming/streaming_internal_test.go
@@ -483,3 +483,46 @@ func book() orderBook {
 		Status:   luno.StatusActive,
 	}
 }
+
+func Test_flatten(t *testing.T) {
+	orders := map[string]order{
+		"1": {ID: "1", Price: decimal.NewFromInt64(1), Volume: decimal.NewFromInt64(1)},
+		"2": {ID: "2", Price: decimal.NewFromInt64(2), Volume: decimal.NewFromInt64(2)},
+		"3": {ID: "3", Price: decimal.NewFromInt64(3), Volume: decimal.NewFromInt64(3)},
+	}
+	expForward := []luno.OrderBookEntry{
+		{ID: "1", Price: decimal.NewFromInt64(1), Volume: decimal.NewFromInt64(1)},
+		{ID: "2", Price: decimal.NewFromInt64(2), Volume: decimal.NewFromInt64(2)},
+		{ID: "3", Price: decimal.NewFromInt64(3), Volume: decimal.NewFromInt64(3)},
+	}
+	expReverse := []luno.OrderBookEntry{
+		{ID: "3", Price: decimal.NewFromInt64(3), Volume: decimal.NewFromInt64(3)},
+		{ID: "2", Price: decimal.NewFromInt64(2), Volume: decimal.NewFromInt64(2)},
+		{ID: "1", Price: decimal.NewFromInt64(1), Volume: decimal.NewFromInt64(1)},
+	}
+
+	forward := flatten(orders, false)
+	for i := 0; i < len(orders); i++ {
+		compareOrderBookEntry(t, expForward[i], forward[i])
+	}
+
+	reverse := flatten(orders, true)
+	for i := 0; i < len(orders); i++ {
+		compareOrderBookEntry(t, expReverse[i], reverse[i])
+	}
+}
+
+func compareOrderBookEntry(t *testing.T, want, got luno.OrderBookEntry) {
+	if got.Price.Cmp(want.Price) != 0 {
+		t.Errorf("Price = %v, want %v", got.Price, want.Price)
+	}
+	got.Price = want.Price
+	if got.Volume.Cmp(want.Volume) != 0 {
+		t.Errorf("Volume = %v, want %v", got.Volume, want.Volume)
+	}
+	got.Volume = want.Volume
+
+	if got != want {
+		t.Errorf("got = %v, want %v", got, want)
+	}
+}

--- a/types.go
+++ b/types.go
@@ -206,7 +206,8 @@ type Order struct {
 }
 
 type OrderBookEntry struct {
-	Id string `json:"id"`
+	// ID is the unique identifier of the order
+	ID string `json:"id"`
 
 	// Limit price at which orders are trading at
 	Price decimal.Decimal `json:"price"`


### PR DESCRIPTION
Reworking [Pull/96](https://github.com/luno/luno-go/pull/96/) 
ID assignment needed to be added to the flatten function.
The naming of the Id field also clashes with the naming convention of IDs in the library so renamed it to ID.
The `Id` field was added a few days ago and is not tagged in a version, so in theory it can still be renamed without being a breaking change.