### PR TITLE
Add missing request parameters for ListTradesRequest

### DIFF
--- a/api.go
+++ b/api.go
@@ -1080,6 +1080,21 @@ type ListTradesRequest struct {
 	// this parameter to either restrict to a shorter window or to iterate over
 	// the trades in case you need more than the 100 most recent trades.
 	Since Time `json:"since" url:"since"`
+
+	// Fetch trades executed before this time, specified as a Unix timestamp in milliseconds.
+	Before Time `json:"before" url:"before"`
+
+	// Filter to trades from (including) this sequence number. Default behaviour is not to include this filter.
+	AfterSequence int64 `json:"after_seq" url:"after_seq"`
+
+	// Filter to trades before (excluding) this sequence number. Default behaviour is not to include this filter.
+	BeforeSequence int64 `json:"before_seq" url:"before_seq"`
+
+	// If set to true, sorts trades in descending order, otherwise ascending order will be assumed.
+	SortDescending bool `json:"sort_desc" url:"sort_desc"`
+
+	// Limit to this number of trades (default 100, max 1000).
+	Limit int64 `json:"limit" url:"limit"`
 }
 
 // ListTradesResponse is the response struct for ListTrades.


### PR DESCRIPTION
ListTrades exposes more parameters than are currently supported in the request object.

https://www.luno.com/en/developers/api#operation/ListUserTrades

This change should allow the rest of the request parameters to be set.