### PR TITLE
gofumpt: Run on whole repo to prevent noise going forwards

### DIFF
--- a/api.go
+++ b/api.go
@@ -909,8 +909,7 @@ func (cl *Client) GetWithdrawal(ctx context.Context, req *GetWithdrawalRequest) 
 }
 
 // ListBeneficiariesResponseRequest is the request struct for ListBeneficiariesResponse.
-type ListBeneficiariesResponseRequest struct {
-}
+type ListBeneficiariesResponseRequest struct{}
 
 // ListBeneficiariesResponseResponse is the response struct for ListBeneficiariesResponse.
 type ListBeneficiariesResponseResponse struct {

--- a/decimal/decimal.go
+++ b/decimal/decimal.go
@@ -146,7 +146,7 @@ func (d Decimal) Sign() int {
 
 // Cmp returns 1 if d>y, -1 if d<y or 0 if d==y.
 func (d Decimal) Cmp(y Decimal) int {
-	var _d, _y = scaleToMax(d, y)
+	_d, _y := scaleToMax(d, y)
 	di := bigIntDefault(_d.i)
 	yi := bigIntDefault(_y.i)
 	return di.Cmp(yi)
@@ -162,7 +162,7 @@ func (d Decimal) Neg() Decimal {
 
 // Add adds y to d and returns the result. d is left unchanged.
 func (d Decimal) Add(y Decimal) Decimal {
-	var _d, _y = scaleToMax(d, y)
+	_d, _y := scaleToMax(d, y)
 	di := bigIntDefault(_d.i)
 	yi := bigIntDefault(_y.i)
 	return New(new(big.Int).Add(di, yi), _d.scale)
@@ -170,7 +170,7 @@ func (d Decimal) Add(y Decimal) Decimal {
 
 // Sub subtracts y from d and returns the result. d is left unchanged.
 func (d Decimal) Sub(y Decimal) Decimal {
-	var _d, _y = scaleToMax(d, y)
+	_d, _y := scaleToMax(d, y)
 	di := bigIntDefault(_d.i)
 	yi := bigIntDefault(_y.i)
 	return New(new(big.Int).Sub(di, yi), _d.scale)

--- a/decimal/decimal_internal_test.go
+++ b/decimal/decimal_internal_test.go
@@ -14,59 +14,59 @@ func TestDecimalUnmarshalJSON(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		testCase{
+		{
 			b:   `""`,
 			err: true,
 		},
-		testCase{
+		{
 			b:   `"abc"`,
 			err: true,
 		},
-		testCase{
+		{
 			b:     `"0."`,
 			err:   false,
 			i:     big.NewInt(0),
 			scale: 0,
 		},
-		testCase{
+		{
 			b:     `"0"`,
 			err:   false,
 			i:     big.NewInt(0),
 			scale: 0,
 		},
-		testCase{
+		{
 			b:     `"0.1"`,
 			err:   false,
 			i:     big.NewInt(1),
 			scale: 1,
 		},
-		testCase{
+		{
 			b:     `"-100.1"`,
 			err:   false,
 			i:     big.NewInt(-1001),
 			scale: 1,
 		},
-		testCase{
+		{
 			b:     `"1.12345678"`,
 			err:   false,
 			i:     big.NewInt(112345678),
 			scale: 8,
 		},
-		testCase{
+		{
 			b:     `"1.123456789"`,
 			err:   false,
 			i:     big.NewInt(1123456789),
 			scale: 9,
 		},
-		testCase{
+		{
 			b:   `"1e8"`,
 			err: true,
 		},
-		testCase{
+		{
 			b:   `"1.1e8"`,
 			err: true,
 		},
-		testCase{
+		{
 			b:   `"1.1234e2"`,
 			err: true,
 		},
@@ -104,37 +104,37 @@ func TestDecimalToScale(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		testCase{
+		{
 			d:     New(big.NewInt(0), 0),
 			scale: 0,
 			exp:   big.NewInt(0),
 		},
-		testCase{
+		{
 			d:     New(big.NewInt(1), 0),
 			scale: 1,
 			exp:   big.NewInt(10),
 		},
-		testCase{
+		{
 			d:     New(big.NewInt(-1), 0),
 			scale: 1,
 			exp:   big.NewInt(-10),
 		},
-		testCase{
+		{
 			d:     New(big.NewInt(12344), 4),
 			scale: 3,
 			exp:   big.NewInt(1234),
 		},
-		testCase{
+		{
 			d:     New(big.NewInt(-12344), 4),
 			scale: 3,
 			exp:   big.NewInt(-1234),
 		},
-		testCase{
+		{
 			d:     New(big.NewInt(12349), 4),
 			scale: 3,
 			exp:   big.NewInt(1234),
 		},
-		testCase{
+		{
 			d:     New(big.NewInt(-12349), 4),
 			scale: 3,
 			exp:   big.NewInt(-1234),

--- a/decimal/decimal_test.go
+++ b/decimal/decimal_test.go
@@ -15,12 +15,12 @@ func TestFloat64(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		testCase{
+		{
 			a:   "0.17800000",
 			b:   "6750.00000000",
 			exp: 1201.5,
 		},
-		testCase{
+		{
 			a:   "0.178000001",
 			b:   "6750.000000001",
 			exp: 1201.500006750178,
@@ -46,19 +46,19 @@ func TestNewFromInt64(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		testCase{
+		{
 			i:   0,
 			exp: "0",
 		},
-		testCase{
+		{
 			i:   1,
 			exp: "1",
 		},
-		testCase{
+		{
 			i:   -1,
 			exp: "-1",
 		},
-		testCase{
+		{
 			i:   1231231,
 			exp: "1231231",
 		},
@@ -81,27 +81,27 @@ func TestNewFromFloat64(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		testCase{
+		{
 			f:     0,
 			scale: 0,
 			exp:   "0",
 		},
-		testCase{
+		{
 			f:     1,
 			scale: 0,
 			exp:   "1",
 		},
-		testCase{
+		{
 			f:     1.12345678,
 			scale: 0,
 			exp:   "1",
 		},
-		testCase{
+		{
 			f:     1.12345678,
 			scale: 8,
 			exp:   "1.12345678",
 		},
-		testCase{
+		{
 			f:     -1.12345678,
 			scale: 4,
 			exp:   "-1.1234",
@@ -124,23 +124,23 @@ func TestNewFromString(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		testCase{
+		{
 			s:   "",
 			err: true,
 		},
-		testCase{
+		{
 			s:   "abc",
 			err: true,
 		},
-		testCase{
+		{
 			s:   "1e8",
 			err: true,
 		},
-		testCase{s: "0"},
-		testCase{s: "1"},
-		testCase{s: "-1.2"},
-		testCase{s: "1.12345678"},
-		testCase{s: "1.123456789"},
+		{s: "0"},
+		{s: "1"},
+		{s: "-1.2"},
+		{s: "1.12345678"},
+		{s: "1.123456789"},
 	}
 
 	for _, test := range testCases {
@@ -178,47 +178,47 @@ func TestDecimalString(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(0), 0),
 			exp: "0",
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(1), 0),
 			exp: "1",
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(12), 1),
 			exp: "1.2",
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(-12), 1),
 			exp: "-1.2",
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(12), 0),
 			exp: "12",
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(112345678), 8),
 			exp: "1.12345678",
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(-112345678), 8),
 			exp: "-1.12345678",
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(1123456789), 9),
 			exp: "1.123456789",
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(-1123456789), 9),
 			exp: "-1.123456789",
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(1123456782), 9),
 			exp: "1.123456782",
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(-1123456782), 9),
 			exp: "-1.123456782",
 		},
@@ -240,19 +240,19 @@ func TestDecimalSign(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(0), 0),
 			exp: 0,
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(1), 0),
 			exp: 1,
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(-1), 0),
 			exp: -1,
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(12345678), 8),
 			exp: 1,
 		},
@@ -275,32 +275,32 @@ func TestDecimalCmp(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		testCase{
+		{
 			d1:  decimal.New(big.NewInt(0), 0),
 			d2:  decimal.New(big.NewInt(0), 0),
 			exp: 0,
 		},
-		testCase{
+		{
 			d1:  decimal.New(big.NewInt(1), 0),
 			d2:  decimal.New(big.NewInt(0), 0),
 			exp: 1,
 		},
-		testCase{
+		{
 			d1:  decimal.New(big.NewInt(-1), 0),
 			d2:  decimal.New(big.NewInt(0), 0),
 			exp: -1,
 		},
-		testCase{
+		{
 			d1:  decimal.New(big.NewInt(100), 1),
 			d2:  decimal.New(big.NewInt(100), 3),
 			exp: 1,
 		},
-		testCase{
+		{
 			d1:  decimal.New(big.NewInt(100), 3),
 			d2:  decimal.New(big.NewInt(100), 1),
 			exp: -1,
 		},
-		testCase{
+		{
 			d1:  decimal.New(big.NewInt(100), 2),
 			d2:  decimal.New(big.NewInt(1), 0),
 			exp: 0,
@@ -323,27 +323,27 @@ func TestDecimalNeg(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(0), 0),
 			exp: decimal.New(big.NewInt(0), 0),
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(1), 0),
 			exp: decimal.New(big.NewInt(-1), 0),
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(-1), 0),
 			exp: decimal.New(big.NewInt(1), 0),
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(5), 1),
 			exp: decimal.New(big.NewInt(-5), 1),
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(-5), 1),
 			exp: decimal.New(big.NewInt(5), 1),
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(12345678), 8),
 			exp: decimal.New(big.NewInt(-12345678), 8),
 		},
@@ -367,37 +367,37 @@ func TestDecimalAdd(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		testCase{
+		{
 			d1:        decimal.New(big.NewInt(0), 0),
 			d2:        decimal.New(big.NewInt(0), 0),
 			exp:       decimal.New(big.NewInt(0), 0),
 			expString: "0",
 		},
-		testCase{
+		{
 			d1:        decimal.New(big.NewInt(1), 0),
 			d2:        decimal.New(big.NewInt(0), 0),
 			exp:       decimal.New(big.NewInt(1), 0),
 			expString: "1",
 		},
-		testCase{
+		{
 			d1:        decimal.New(big.NewInt(-1), 0),
 			d2:        decimal.New(big.NewInt(0), 0),
 			exp:       decimal.New(big.NewInt(-1), 0),
 			expString: "-1",
 		},
-		testCase{
+		{
 			d1:        decimal.New(big.NewInt(1), 0),
 			d2:        decimal.New(big.NewInt(112345678), 8),
 			exp:       decimal.New(big.NewInt(212345678), 8),
 			expString: "2.12345678",
 		},
-		testCase{
+		{
 			d1:        decimal.New(big.NewInt(-1123), 3),
 			d2:        decimal.New(big.NewInt(-1123), 3),
 			exp:       decimal.New(big.NewInt(-2246), 3),
 			expString: "-2.246",
 		},
-		testCase{
+		{
 			d1:        decimal.New(big.NewInt(112345678), 8),
 			d2:        decimal.New(big.NewInt(112345678), 8),
 			exp:       decimal.New(big.NewInt(224691356), 8),
@@ -430,37 +430,37 @@ func TestDecimalSub(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		testCase{
+		{
 			d1:        decimal.New(big.NewInt(0), 0),
 			d2:        decimal.New(big.NewInt(0), 0),
 			exp:       decimal.New(big.NewInt(0), 0),
 			expString: "0",
 		},
-		testCase{
+		{
 			d1:        decimal.New(big.NewInt(1), 0),
 			d2:        decimal.New(big.NewInt(0), 0),
 			exp:       decimal.New(big.NewInt(1), 0),
 			expString: "1",
 		},
-		testCase{
+		{
 			d1:        decimal.New(big.NewInt(-1), 0),
 			d2:        decimal.New(big.NewInt(0), 0),
 			exp:       decimal.New(big.NewInt(-1), 0),
 			expString: "-1",
 		},
-		testCase{
+		{
 			d1:        decimal.New(big.NewInt(1), 0),
 			d2:        decimal.New(big.NewInt(112345678), 8),
 			exp:       decimal.New(big.NewInt(-12345678), 8),
 			expString: "-0.12345678",
 		},
-		testCase{
+		{
 			d1:        decimal.New(big.NewInt(-1123), 3),
 			d2:        decimal.New(big.NewInt(-1123), 3),
 			exp:       decimal.New(big.NewInt(0), 3),
 			expString: "0.000",
 		},
-		testCase{
+		{
 			d1:        decimal.New(big.NewInt(112345678), 8),
 			d2:        decimal.New(big.NewInt(112345678), 8),
 			exp:       decimal.New(big.NewInt(0), 8),
@@ -492,32 +492,32 @@ func TestDecimalMulInt64(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(0), 0),
 			y:   0,
 			exp: "0",
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(100), 0),
 			y:   100,
 			exp: "10000",
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(-100), 0),
 			y:   100,
 			exp: "-10000",
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(100), 8),
 			y:   100,
 			exp: "0.00010000",
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(-100), 8),
 			y:   100,
 			exp: "-0.00010000",
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(17823), 4),
 			y:   124,
 			exp: "221.0052",
@@ -541,32 +541,32 @@ func TestDecimalDivInt64(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(1), 0),
 			y:   1,
 			exp: "1",
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(-100), 0),
 			y:   100,
 			exp: "-1",
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(100), 8),
 			y:   100,
 			exp: "0.00000001",
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(-100), 8),
 			y:   100,
 			exp: "-0.00000001",
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(1), 4),
 			y:   10,
 			exp: "0.0000",
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(17823), 4),
 			y:   124,
 			exp: "0.0143",
@@ -590,32 +590,32 @@ func TestDecimalMul(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		testCase{
+		{
 			d:   decimal.Decimal{},
 			y:   decimal.Decimal{},
 			exp: "0",
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(1), 0),
 			y:   decimal.New(big.NewInt(1), 0),
 			exp: "1",
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(1), 0),
 			y:   decimal.New(big.NewInt(-1), 0),
 			exp: "-1",
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(1), 3),
 			y:   decimal.New(big.NewInt(1), 3),
 			exp: "0.000001",
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(1234), 3),
 			y:   decimal.New(big.NewInt(5678), 8),
 			exp: "0.00007006652",
 		},
-		testCase{
+		{
 			d:   decimal.New(big.NewInt(100), 2),
 			y:   decimal.New(big.NewInt(100), 2),
 			exp: "1.0000",
@@ -640,37 +640,37 @@ func TestDecimalDivNoPanic(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		testCase{
+		{
 			d:     decimal.New(big.NewInt(1), 0),
 			y:     decimal.New(big.NewInt(1), 0),
 			scale: 0,
 			exp:   "1",
 		},
-		testCase{
+		{
 			d:     decimal.New(big.NewInt(1), 0),
 			y:     decimal.New(big.NewInt(10), 0),
 			scale: 2,
 			exp:   "0.10",
 		},
-		testCase{
+		{
 			d:     decimal.New(big.NewInt(1), 0),
 			y:     decimal.New(big.NewInt(-10), 0),
 			scale: 2,
 			exp:   "-0.10",
 		},
-		testCase{
+		{
 			d:     decimal.New(big.NewInt(5000), 4),
 			y:     decimal.New(big.NewInt(15000), 4),
 			scale: 2,
 			exp:   "0.33",
 		},
-		testCase{
+		{
 			d:     decimal.New(big.NewInt(5000), 4),
 			y:     decimal.New(big.NewInt(15000), 4),
 			scale: 10,
 			exp:   "0.3333333333",
 		},
-		testCase{
+		{
 			d:     decimal.New(big.NewInt(1234), 2),
 			y:     decimal.New(big.NewInt(5678), 8),
 			scale: 5,
@@ -704,15 +704,15 @@ func TestDecimalDivPanic(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		testCase{
+		{
 			d: decimal.Decimal{},
 			y: decimal.Decimal{},
 		},
-		testCase{
+		{
 			d: decimal.New(big.NewInt(1), 0),
 			y: decimal.Decimal{},
 		},
-		testCase{
+		{
 			d: decimal.New(big.NewInt(1), 0),
 			y: decimal.New(big.NewInt(0), 0),
 		},

--- a/errors_test.go
+++ b/errors_test.go
@@ -11,21 +11,21 @@ func TestError(t *testing.T) {
 		Message: "Example error message!",
 	}
 
-	 if err.Error() != "Example error message! (ErrFoo)" {
-	 	t.Errorf("Unexpected error formatting")
-	 }
+	if err.Error() != "Example error message! (ErrFoo)" {
+		t.Errorf("Unexpected error formatting")
+	}
 
-	 if err.ErrCode() != "ErrFoo" {
-	 	t.Errorf("Unexpected error code")
-	 }
+	if err.ErrCode() != "ErrFoo" {
+		t.Errorf("Unexpected error code")
+	}
 }
 
 func TestIsErrorCode(t *testing.T) {
 	testCases := []struct {
 		name string
-		err error
+		err  error
 		code string
-		exp bool
+		exp  bool
 	}{
 		{
 			name: "nil error",
@@ -35,7 +35,7 @@ func TestIsErrorCode(t *testing.T) {
 		},
 		{
 			name: "luno error with code present",
-			err:  Error{
+			err: Error{
 				Code:    "ErrFoo",
 				Message: "example error message",
 			},
@@ -44,7 +44,7 @@ func TestIsErrorCode(t *testing.T) {
 		},
 		{
 			name: "luno error with different code",
-			err:  Error{
+			err: Error{
 				Code:    "ErrBar",
 				Message: "example error message",
 			},

--- a/luno.go
+++ b/luno.go
@@ -95,8 +95,8 @@ func (cl *Client) SetDebug(debug bool) {
 }
 
 func (cl *Client) do(ctx context.Context, method, path string,
-	req, res interface{}, auth bool) error {
-
+	req, res interface{}, auth bool,
+) error {
 	err := cl.rateLimiter.Wait(ctx)
 	if err != nil {
 		return err

--- a/streaming/streaming.go
+++ b/streaming/streaming.go
@@ -56,9 +56,11 @@ type orderList []luno.OrderBookEntry
 func (ol orderList) Less(i, j int) bool {
 	return ol[i].Price.Cmp(ol[j].Price) < 0
 }
+
 func (ol orderList) Swap(i, j int) {
 	ol[i], ol[j] = ol[j], ol[i]
 }
+
 func (ol orderList) Len() int {
 	return len(ol)
 }
@@ -80,8 +82,10 @@ func flatten(m map[string]order, reverse bool) []luno.OrderBookEntry {
 	return ol
 }
 
-type ConnectCallback func(*Conn)
-type UpdateCallback func(Update)
+type (
+	ConnectCallback func(*Conn)
+	UpdateCallback  func(Update)
+)
 
 type Conn struct {
 	keyID, keySecret string
@@ -327,8 +331,8 @@ func (c *Conn) receivedUpdate(u Update) error {
 }
 
 func decTrade(m map[string]order, id string, base decimal.Decimal) (
-	bool, error) {
-
+	bool, error,
+) {
 	o, ok := m[id]
 	if !ok {
 		return false, nil
@@ -421,8 +425,8 @@ func (c *Conn) processStatus(u StatusUpdate) error {
 // OrderBookSnapshot returns the latest order book.
 // Deprecated at v0.0.8, use Snapshot().
 func (c *Conn) OrderBookSnapshot() (
-	int64, []luno.OrderBookEntry, []luno.OrderBookEntry) {
-
+	int64, []luno.OrderBookEntry, []luno.OrderBookEntry,
+) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 

--- a/streaming/streaming_internal_test.go
+++ b/streaming/streaming_internal_test.go
@@ -86,7 +86,8 @@ func TestReceivedUpdate(t *testing.T) {
 		{
 			name: "success process twice",
 			args: args{
-				u: Update{Sequence: 2,
+				u: Update{
+					Sequence: 2,
 					TradeUpdates: []*TradeUpdate{
 						{
 							Sequence:     1,
@@ -108,8 +109,10 @@ func TestReceivedUpdate(t *testing.T) {
 			expected: expected{
 				wantErr: false,
 				asks:    asksMap(),
-				bids: bidsMap(order{ID: "1", Price: decimal.NewFromFloat64(120.0, 1),
-					Volume: decimal.NewFromFloat64(0.07, 2)}),
+				bids: bidsMap(order{
+					ID: "1", Price: decimal.NewFromFloat64(120.0, 1),
+					Volume: decimal.NewFromFloat64(0.07, 2),
+				}),
 				lastTrade: TradeUpdate{
 					Sequence:     2,
 					Base:         decimal.NewFromFloat64(0.01, 2),
@@ -124,7 +127,8 @@ func TestReceivedUpdate(t *testing.T) {
 		{
 			name: "success ask/bid",
 			args: args{
-				u: Update{Sequence: 2,
+				u: Update{
+					Sequence: 2,
 					TradeUpdates: []*TradeUpdate{
 						{
 							Sequence:     1,
@@ -145,10 +149,14 @@ func TestReceivedUpdate(t *testing.T) {
 			},
 			expected: expected{
 				wantErr: false,
-				asks: asksMap(order{ID: "4", Price: decimal.NewFromFloat64(180.0, 1),
-					Volume: decimal.NewFromFloat64(0.99, 2)}),
-				bids: bidsMap(order{ID: "3", Price: decimal.NewFromFloat64(100.0, 1),
-					Volume: decimal.NewFromFloat64(0.99, 2)}),
+				asks: asksMap(order{
+					ID: "4", Price: decimal.NewFromFloat64(180.0, 1),
+					Volume: decimal.NewFromFloat64(0.99, 2),
+				}),
+				bids: bidsMap(order{
+					ID: "3", Price: decimal.NewFromFloat64(100.0, 1),
+					Volume: decimal.NewFromFloat64(0.99, 2),
+				}),
 				lastTrade: TradeUpdate{
 					Sequence:     2,
 					Base:         decimal.NewFromFloat64(0.01, 2),
@@ -163,7 +171,8 @@ func TestReceivedUpdate(t *testing.T) {
 		{
 			name: "success delete from ask",
 			args: args{
-				u: Update{Sequence: 2,
+				u: Update{
+					Sequence: 2,
 					TradeUpdates: []*TradeUpdate{
 						{
 							Sequence:     1,
@@ -236,12 +245,16 @@ func TestReceivedCreate(t *testing.T) {
 		{
 			name: "fail invalid type",
 			args: args{
-				u: Update{Sequence: 2,
-					CreateUpdate: &CreateUpdate{OrderID: "8",
-						Price:  decimal.NewFromFloat64(6700.56, 2),
-						Type:   "ASKBID",
-						Volume: decimal.NewFromFloat64(0.01, 2)},
-				}},
+				u: Update{
+					Sequence: 2,
+					CreateUpdate: &CreateUpdate{
+						OrderID: "8",
+						Price:   decimal.NewFromFloat64(6700.56, 2),
+						Type:    "ASKBID",
+						Volume:  decimal.NewFromFloat64(0.01, 2),
+					},
+				},
+			},
 			expected: expected{
 				wantErr: true,
 			},
@@ -249,17 +262,23 @@ func TestReceivedCreate(t *testing.T) {
 		{
 			name: "create ask",
 			args: args{
-				u: Update{Sequence: 2,
-					CreateUpdate: &CreateUpdate{OrderID: "8",
-						Price:  decimal.NewFromFloat64(6700.56, 2),
-						Type:   "ASK",
-						Volume: decimal.NewFromFloat64(0.01, 2)},
-				}},
+				u: Update{
+					Sequence: 2,
+					CreateUpdate: &CreateUpdate{
+						OrderID: "8",
+						Price:   decimal.NewFromFloat64(6700.56, 2),
+						Type:    "ASK",
+						Volume:  decimal.NewFromFloat64(0.01, 2),
+					},
+				},
+			},
 			expected: expected{
 				wantErr: false,
-				asks: asksMap(order{ID: "8",
+				asks: asksMap(order{
+					ID:     "8",
 					Price:  decimal.NewFromFloat64(6700.56, 2),
-					Volume: decimal.NewFromFloat64(0.01, 2)}),
+					Volume: decimal.NewFromFloat64(0.01, 2),
+				}),
 				bids:   bidsMap(),
 				seq:    2,
 				status: luno.StatusActive,
@@ -268,18 +287,24 @@ func TestReceivedCreate(t *testing.T) {
 		{
 			name: "create bid",
 			args: args{
-				u: Update{Sequence: 2,
-					CreateUpdate: &CreateUpdate{OrderID: "7",
-						Price:  decimal.NewFromFloat64(6700.54, 2),
-						Type:   "BID",
-						Volume: decimal.NewFromFloat64(0.01, 2)},
-				}},
+				u: Update{
+					Sequence: 2,
+					CreateUpdate: &CreateUpdate{
+						OrderID: "7",
+						Price:   decimal.NewFromFloat64(6700.54, 2),
+						Type:    "BID",
+						Volume:  decimal.NewFromFloat64(0.01, 2),
+					},
+				},
+			},
 			expected: expected{
 				wantErr: false,
 				asks:    asksMap(),
-				bids: bidsMap(order{ID: "7",
+				bids: bidsMap(order{
+					ID:     "7",
 					Price:  decimal.NewFromFloat64(6700.54, 2),
-					Volume: decimal.NewFromFloat64(0.01, 2)}),
+					Volume: decimal.NewFromFloat64(0.01, 2),
+				}),
 				seq:    2,
 				status: luno.StatusActive,
 			},
@@ -317,8 +342,10 @@ func TestReceivedDelete(t *testing.T) {
 		{
 			name: "success not in asks/bids",
 			args: args{
-				u: Update{Sequence: 2,
-					DeleteUpdate: &DeleteUpdate{OrderID: "8"}},
+				u: Update{
+					Sequence:     2,
+					DeleteUpdate: &DeleteUpdate{OrderID: "8"},
+				},
 			},
 			expected: expected{
 				wantErr: false,
@@ -331,16 +358,22 @@ func TestReceivedDelete(t *testing.T) {
 		{
 			name: "delete ask",
 			args: args{
-				u: Update{Sequence: 2,
-					DeleteUpdate: &DeleteUpdate{OrderID: "4"}},
+				u: Update{
+					Sequence:     2,
+					DeleteUpdate: &DeleteUpdate{OrderID: "4"},
+				},
 			},
 			expected: expected{
 				wantErr: false,
 				asks: map[string]order{
-					"2": {ID: "2", Price: decimal.NewFromFloat64(150.0, 1),
-						Volume: decimal.NewFromFloat64(0.5, 1)},
-					"6": {ID: "6", Price: decimal.NewFromFloat64(200.0, 1),
-						Volume: decimal.NewFromFloat64(0.1, 1)},
+					"2": {
+						ID: "2", Price: decimal.NewFromFloat64(150.0, 1),
+						Volume: decimal.NewFromFloat64(0.5, 1),
+					},
+					"6": {
+						ID: "6", Price: decimal.NewFromFloat64(200.0, 1),
+						Volume: decimal.NewFromFloat64(0.1, 1),
+					},
 				},
 				bids:   bidsMap(),
 				seq:    2,
@@ -370,12 +403,18 @@ func TestReceivedDelete(t *testing.T) {
 
 func bidsMap(o ...order) map[string]order {
 	res := map[string]order{
-		"1": {ID: "1", Price: decimal.NewFromFloat64(120.0, 1),
-			Volume: decimal.NewFromFloat64(0.1, 1)},
-		"3": {ID: "3", Price: decimal.NewFromFloat64(100.0, 1),
-			Volume: decimal.NewFromFloat64(1.0, 1)},
-		"5": {ID: "5", Price: decimal.NewFromFloat64(110.0, 1),
-			Volume: decimal.NewFromFloat64(0.5, 1)},
+		"1": {
+			ID: "1", Price: decimal.NewFromFloat64(120.0, 1),
+			Volume: decimal.NewFromFloat64(0.1, 1),
+		},
+		"3": {
+			ID: "3", Price: decimal.NewFromFloat64(100.0, 1),
+			Volume: decimal.NewFromFloat64(1.0, 1),
+		},
+		"5": {
+			ID: "5", Price: decimal.NewFromFloat64(110.0, 1),
+			Volume: decimal.NewFromFloat64(0.5, 1),
+		},
 	}
 	for _, v := range o {
 		res[v.ID] = v
@@ -385,12 +424,18 @@ func bidsMap(o ...order) map[string]order {
 
 func asksMap(o ...order) map[string]order {
 	res := map[string]order{
-		"2": {ID: "2", Price: decimal.NewFromFloat64(150.0, 1),
-			Volume: decimal.NewFromFloat64(0.5, 1)},
-		"4": {ID: "4", Price: decimal.NewFromFloat64(180.0, 1),
-			Volume: decimal.NewFromFloat64(1.0, 1)},
-		"6": {ID: "6", Price: decimal.NewFromFloat64(200.0, 1),
-			Volume: decimal.NewFromFloat64(0.1, 1)},
+		"2": {
+			ID: "2", Price: decimal.NewFromFloat64(150.0, 1),
+			Volume: decimal.NewFromFloat64(0.5, 1),
+		},
+		"4": {
+			ID: "4", Price: decimal.NewFromFloat64(180.0, 1),
+			Volume: decimal.NewFromFloat64(1.0, 1),
+		},
+		"6": {
+			ID: "6", Price: decimal.NewFromFloat64(200.0, 1),
+			Volume: decimal.NewFromFloat64(0.1, 1),
+		},
 	}
 	for _, v := range o {
 		res[v.ID] = v
@@ -464,20 +509,32 @@ func validateResult(err error, t *testing.T, exp expected, c *Conn) {
 func book() orderBook {
 	return orderBook{
 		Bids: []*order{
-			{ID: "1", Price: decimal.NewFromFloat64(120.0, 1),
-				Volume: decimal.NewFromFloat64(0.1, 1)},
-			{ID: "5", Price: decimal.NewFromFloat64(110.0, 1),
-				Volume: decimal.NewFromFloat64(0.5, 1)},
-			{ID: "3", Price: decimal.NewFromFloat64(100.0, 1),
-				Volume: decimal.NewFromFloat64(1.0, 1)},
+			{
+				ID: "1", Price: decimal.NewFromFloat64(120.0, 1),
+				Volume: decimal.NewFromFloat64(0.1, 1),
+			},
+			{
+				ID: "5", Price: decimal.NewFromFloat64(110.0, 1),
+				Volume: decimal.NewFromFloat64(0.5, 1),
+			},
+			{
+				ID: "3", Price: decimal.NewFromFloat64(100.0, 1),
+				Volume: decimal.NewFromFloat64(1.0, 1),
+			},
 		},
 		Asks: []*order{
-			{ID: "2", Price: decimal.NewFromFloat64(150.0, 1),
-				Volume: decimal.NewFromFloat64(0.5, 1)},
-			{ID: "4", Price: decimal.NewFromFloat64(180.0, 1),
-				Volume: decimal.NewFromFloat64(1.0, 1)},
-			{ID: "6", Price: decimal.NewFromFloat64(200.0, 1),
-				Volume: decimal.NewFromFloat64(0.1, 1)},
+			{
+				ID: "2", Price: decimal.NewFromFloat64(150.0, 1),
+				Volume: decimal.NewFromFloat64(0.5, 1),
+			},
+			{
+				ID: "4", Price: decimal.NewFromFloat64(180.0, 1),
+				Volume: decimal.NewFromFloat64(1.0, 1),
+			},
+			{
+				ID: "6", Price: decimal.NewFromFloat64(200.0, 1),
+				Volume: decimal.NewFromFloat64(0.1, 1),
+			},
 		},
 		Sequence: 1,
 		Status:   luno.StatusActive,

--- a/time_test.go
+++ b/time_test.go
@@ -15,22 +15,22 @@ func TestTimeUnmarshalJSON(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		testCase{
+		{
 			err: true,
 		},
-		testCase{
+		{
 			in:  []byte{},
 			err: true,
 		},
-		testCase{
+		{
 			in:  []byte("abc"),
 			err: true,
 		},
-		testCase{
+		{
 			in:  []byte("123456"),
 			exp: luno.Time(time.Unix(0, 123456e6)),
 		},
-		testCase{
+		{
 			in:  []byte("-123456"),
 			exp: luno.Time(time.Unix(0, -123456e6)),
 		},
@@ -61,15 +61,15 @@ func TestTimeMarshalJSON(t *testing.T) {
 	now := time.Now()
 
 	testCases := []testCase{
-		testCase{
+		{
 			in:  luno.Time{},
 			exp: time.Time{}.String(),
 		},
-		testCase{
+		{
 			in:  luno.Time(now),
 			exp: now.String(),
 		},
-		testCase{
+		{
 			in:  luno.Time(time.Date(2006, 1, 2, 3, 4, 5, 999, time.UTC)),
 			exp: time.Date(2006, 1, 2, 3, 4, 5, 999, time.UTC).String(),
 		},

--- a/util.go
+++ b/util.go
@@ -49,7 +49,7 @@ func makeURLValues(v interface{}) url.Values {
 		case reflect.Float64:
 			ss = append(ss, strconv.FormatFloat(fieldValue.Float(), 'f', 4, 64))
 		case reflect.Slice:
-			 if field.Type.Elem().Kind() == reflect.String {
+			if field.Type.Elem().Kind() == reflect.String {
 				for i := 0; i < fieldValue.Len(); i++ {
 					ss = append(ss, fieldValue.Index(i).String())
 				}

--- a/util_internal_test.go
+++ b/util_internal_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestMakeURLValues(t *testing.T) {
-
 	type S string
 
 	type Req struct {
@@ -31,7 +30,7 @@ func TestMakeURLValues(t *testing.T) {
 	}{
 		{
 			name: "nil",
-			r: nil,
+			r:    nil,
 		},
 		{
 			name: "valid time",
@@ -66,7 +65,7 @@ func TestMakeURLValues(t *testing.T) {
 			expected: "amt=0.1&ast=foo&ast=bar&b=true&f32=42.4200&f64=42.4200&i=42&i64=42&s=foo&t=&ts=foo",
 		},
 		{
-			name:"valid amount",
+			name: "valid amount",
 			r: &Req{
 				S:   "foo",
 				I:   42,
@@ -79,7 +78,7 @@ func TestMakeURLValues(t *testing.T) {
 				Amt: decimal.NewFromFloat64(0.0001, 10),
 				T:   Time(time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)),
 			},
-			expected:"amt=0.0001000000&ast=foo&ast=bar&b=true&f32=42.4200&f64=42.4200&i=42&i64=42&s=foo&t=1514764800000&ts=foo",
+			expected: "amt=0.0001000000&ast=foo&ast=bar&b=true&f32=42.4200&f64=42.4200&i=42&i64=42&s=foo&t=1514764800000&ts=foo",
 		},
 	}
 


### PR DESCRIPTION
- gofumpt runs on our precommit hooks, so running it now will avoid noise in MRs going forwards when these updates get made