### PR TITLE
Fix HTML links on godoc

### DIFF
--- a/api.go
+++ b/api.go
@@ -1534,14 +1534,15 @@ func (cl *Client) PostMarketOrder(ctx context.Context, req *PostMarketOrderReque
 type SendRequest struct {
 	// Destination address or email address.
 	//
-	// <b>Note</b>:
-	// <ul>
-	// <li>Ethereum addresses must be
-	// <a href="https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md" target="_blank" rel="nofollow">checksummed</a>.</li>
-	// <li>Ethereum sends to email addresses are not supported.</li>
-	// </ul>
+	// # Note:
+	//
+	//   - Ethereum addresses must be [checksummed]
+	//
+	//   - Ethereum sends to email addresses are not supported.
 	//
 	// required: true
+	//
+	// [checksummed]: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md
 	Address string `json:"address" url:"address"`
 
 	// Amount to send as a decimal string.


### PR DESCRIPTION
Fixed the HTML links for SendRequest, additionally fixed the unordered list, and made the <b>Note</b> look emphasized.

I was not able to fix the HTML link in the PostMarketOrder since the full URL was not provided. We can show code blocks instead of using the 'code' tags but the code will be displayed in a new line. which would look as follows.

![image](https://github.com/luno/luno-go/assets/48934781/10bc9204-739a-4f1e-ae3d-34d123eb6c99)

Addresses: https://github.com/luno/luno-go/issues/97