### PR TITLE
ci: Update go version in test.yml to be 1.21

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16
+        go-version: 1.21
     - name: Build
       run: go build -v ./...
     - name: Vet


### PR DESCRIPTION
### Changed
-  go version in test.yml to be 1.21