### PR TITLE
feat(api, types): add transfer_id to withdrawal types

### DIFF
--- a/api.go
+++ b/api.go
@@ -898,7 +898,7 @@ type GetWithdrawalResponse struct {
 	// Status
 	Status Status `json:"status"`
 
-	// Transfer ID
+	// Transfer ID if the corresponding transfer if it has been initiated
 	TransferId string `json:"transfer_id"`
 
 	// Type distinguishes between different withdrawal methods where more than one is supported

--- a/api.go
+++ b/api.go
@@ -898,6 +898,9 @@ type GetWithdrawalResponse struct {
 	// Status
 	Status Status `json:"status"`
 
+	// Transfer ID
+	TransferId string `json:"transfer_id"`
+
 	// Type distinguishes between different withdrawal methods where more than one is supported
 	// for the given currency.
 	Type string `json:"type"`
@@ -918,8 +921,7 @@ func (cl *Client) GetWithdrawal(ctx context.Context, req *GetWithdrawalRequest) 
 }
 
 // ListBeneficiariesResponseRequest is the request struct for ListBeneficiariesResponse.
-type ListBeneficiariesResponseRequest struct {
-}
+type ListBeneficiariesResponseRequest struct{}
 
 // ListBeneficiariesResponseResponse is the response struct for ListBeneficiariesResponse.
 type ListBeneficiariesResponseResponse struct {

--- a/types.go
+++ b/types.go
@@ -557,6 +557,9 @@ type Withdrawal struct {
 	// Status
 	Status Status `json:"status"`
 
+	// Transfer ID if the corresponding transfer if it has been initiated
+	TransferId string `json:"transfer_id"`
+
 	// Type distinguishes between different withdrawal methods where more than one is supported
 	// for the given currency.
 	Type string `json:"type"`


### PR DESCRIPTION
Align the Go package with the Luno API by including the transfer id of a withdrawal in the GetWithdrawalResponse and Withdrawal structs.