### PR TITLE
renovate: Use common config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ],
-  "branchConcurrentLimit": 3,
-  "labels":["Bot::Renovate"],
-  "semanticCommits":  "disabled",
-  "commitMessagePrefix": "renovate:",
+  "extends": ["github>luno/.github"],
   "reviewers": [
     "echarrod"
   ],


### PR DESCRIPTION
### Changed
- Renovate to use common config added in https://github.com/luno/.github/pull/2