### PR TITLE
Add option to specify custom backoff handler

### DIFF
--- a/streaming/backoff.go
+++ b/streaming/backoff.go
@@ -1,0 +1,18 @@
+package streaming
+
+import (
+	"math"
+	"math/rand"
+	"time"
+)
+
+type backoffParams struct {
+	attempts    int
+	lastAttempt time.Time
+}
+
+func defaultBackoffHandler(attempts int) time.Duration {
+	jitter := time.Duration(rand.Intn(200)-100) * time.Millisecond                       // ±100ms
+	backoff := time.Duration(math.Min(math.Pow(2, float64(attempts)), 60)) * time.Second // Exponential backoff up to 60s
+	return backoff + jitter
+}

--- a/streaming/options.go
+++ b/streaming/options.go
@@ -1,5 +1,9 @@
 package streaming
 
+import (
+	"time"
+)
+
 type DialOption func(*Conn)
 
 // WithUpdateCallback returns an options which sets a callback function for
@@ -16,5 +20,15 @@ func WithUpdateCallback(fn UpdateCallback) DialOption {
 func WithConnectCallback(fn ConnectCallback) DialOption {
 	return func(c *Conn) {
 		c.connectCallback = fn
+	}
+}
+
+// WithBackoffHandler specify custom handler to calculate backoff duration after each disconnect. Attempt will increment
+// with each subsequent call until the attemptReset duration exceeds the duration since the last disconnect, at which point it
+// will reset to 0.
+func WithBackoffHandler(fn BackoffHandler, attemptReset time.Duration) DialOption {
+	return func(c *Conn) {
+		c.backoffHandler = fn
+		c.attemptReset = attemptReset
 	}
 }

--- a/streaming/streaming_test.go
+++ b/streaming/streaming_test.go
@@ -1,7 +1,9 @@
 package streaming
 
 import (
+	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/luno/luno-go"
 	"github.com/luno/luno-go/decimal"
@@ -122,6 +124,104 @@ func TestFlatten(t *testing.T) {
 				if expO.Volume.Cmp(o.Volume) != 0 {
 					t.Errorf("order %d volume doesn't match %s, expected %s", i, o.Volume, expO.Volume)
 				}
+			}
+		})
+	}
+}
+
+func TestBackoff(t *testing.T) {
+	tcs := []struct {
+		name         string
+		fn           BackoffHandler
+		attemptReset time.Duration
+		p            *backoffParams
+		seed         func()
+		reqTS        time.Time
+		expBackoff   time.Duration
+		expParams    backoffParams
+	}{
+		{
+			name: "default",
+			fn:   defaultBackoffHandler,
+			p:    &backoffParams{},
+			seed: func() {
+				// Seed random generator to test default backoff handler
+				rand.Seed(123)
+			},
+			reqTS:      time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC),
+			expBackoff: 1935000000,
+			expParams: backoffParams{
+				attempts:    1,
+				lastAttempt: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			name: "second per attempt",
+			p:    &backoffParams{},
+			fn: func(attempt int) time.Duration {
+				return time.Second * time.Duration(attempt)
+			},
+			reqTS:      time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC),
+			expBackoff: time.Second,
+			expParams: backoffParams{
+				attempts:    1,
+				lastAttempt: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			name: "second per attempt 3rd attempt",
+			p: &backoffParams{
+				attempts:    3,
+				lastAttempt: time.Date(2024, 2, 3, 0, 10, 0, 0, time.UTC),
+			},
+			fn: func(attempt int) time.Duration {
+				return time.Second * time.Duration(attempt)
+			},
+			attemptReset: defaultAttemptReset,
+			reqTS:        time.Date(2024, 2, 3, 0, 20, 0, 0, time.UTC),
+			expBackoff:   time.Second * 4,
+			expParams: backoffParams{
+				attempts:    4,
+				lastAttempt: time.Date(2024, 2, 3, 0, 20, 0, 0, time.UTC),
+			},
+		},
+		{
+			name: "second per attempt 3rd attempt reset",
+			p: &backoffParams{
+				attempts:    3,
+				lastAttempt: time.Date(2024, 2, 3, 0, 10, 0, 0, time.UTC),
+			},
+			fn: func(attempt int) time.Duration {
+				return time.Second * time.Duration(attempt)
+			},
+			attemptReset: time.Minute * 10,
+			reqTS:        time.Date(2024, 2, 3, 0, 20, 0, 0, time.UTC),
+			expBackoff:   time.Second,
+			expParams: backoffParams{
+				attempts:    1,
+				lastAttempt: time.Date(2024, 2, 3, 0, 20, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.seed != nil {
+				tc.seed()
+			}
+
+			c := &Conn{
+				backoffHandler: tc.fn,
+				attemptReset:   tc.attemptReset,
+			}
+
+			dt := c.calculateBackoff(tc.p, tc.reqTS)
+			if dt != tc.expBackoff {
+				t.Errorf("backoff %d doesn't match expect backoff %d", dt, tc.expBackoff)
+			}
+
+			if tc.expParams != *tc.p {
+				t.Errorf("params doesn't match expected params")
 			}
 		})
 	}


### PR DESCRIPTION
The default way of handling backoffs may be a bit too aggressive for some use cases. Add option to add custom backoff handler and duration until backoff resets.