### PR TITLE
renovate: Correct parent config reference

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>luno/.github"],
+  "extends": ["github>luno/.github:renovate-config"],
   "reviewers": [
     "echarrod"
   ],


### PR DESCRIPTION
### Fixed
- Config name: renovate-config matches the JSON filename present at https://github.com/luno/.github/ (see [docs](https://docs.renovatebot.com/config-presets/))
- Tested with forks:
  - https://github.com/echarrod/.github
  - https://github.com/echarrod/luno-go
 - Started to change the file name in https://github.com/luno/.github/pull/3, but thought this was better since that repo has non-renovate items in, so calling it `default.json` wouldn't indicate what it's being used for