### PR TITLE
gomod: Update version to Go 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/luno-go
 
-go 1.20
+go 1.21
 
 require (
 	github.com/gorilla/websocket v1.5.3


### PR DESCRIPTION
### Changed
- Following official Go stance of supporting two most recent major versions