### PR TITLE
go: Update to 1.24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go: [ '1.21', '1.22', '1' ]
+        go: [ '1.23', '1' ]
     runs-on: ubuntu-latest
 
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/luno-go
 
-go 1.21
+go 1.24
 
 require (
 	github.com/gorilla/websocket v1.5.3


### PR DESCRIPTION
### Changed
- Go version tested
- Go version in go.mod

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Go version in the project configuration and CI workflow to use Go 1.24.
  - Adjusted CI workflow to test against Go 1.23 and the latest minor version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->