### PR TITLE
sonar: Update deprecated action

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -25,4 +25,4 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         if: github.event.pull_request.head.repo.full_name == github.repository || env.SONAR_TOKEN != ''
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@master

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -25,4 +25,4 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         if: github.event.pull_request.head.repo.full_name == github.repository || env.SONAR_TOKEN != ''
-        uses: SonarSource/sonarqube-scan-action@master
+        uses: SonarSource/sonarqube-scan-action@v5.1.0


### PR DESCRIPTION
This PR replaces the deprecated `sonarsource/sonarcloud-github-action@master` with the recommended `SonarSource/sonarqube-scan-action@master` as suggested in the CI warning message.

The warning message was:
```
::warning title=SonarScanner::This action is deprecated and will be removed in a future release. Please use the sonarqube-scan-action action instead. The sonarqube-scan-action is a drop-in replacement for this action.
```

This is a drop-in replacement that will resolve the deprecation warning while maintaining the same functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the workflow for Sonar report generation to use a different action for uploading coverage reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->