### PR TITLE
time: Update time MarshallJSON so 0 values are marshalled successfully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-05-16
+
+### Changed
+- Modified `Time.MarshalJSON()` to safely serialize time values as JSON. Added support for environment variable `LUNO_TIME_LEGACY_FORMAT` to control the output format:
+  - When `LUNO_TIME_LEGACY_FORMAT=true`: Returns the original string format (with proper JSON quoting)
+  - Default behavior (no env var or any other value): Returns millisecond timestamp values
+
+### Migration Guide
+If you rely on the string format previously returned by `Time.MarshalJSON()`, you have three options:
+
+1. **Option 1**: Set the `LUNO_TIME_LEGACY_FORMAT=true` environment variable in your application
+2. **Option 2**: Update your client code to handle numeric millisecond timestamp values
+3. **Option 3**: Use the provided migration helper in `_examples/time_migration/main.go`
+
+Note that the original implementation could produce invalid JSON when embedded in larger JSON structures, so the new approach is recommended for better JSON compatibility.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ This Go package provides a wrapper for the [Luno API](https://www.luno.com/api).
 Please visit [godoc.org](https://godoc.org/github.com/luno/luno-go) for the full
 package documentation.
 
+## Changes to Time JSON Format (v0.1.0)
+
+Starting with version 0.1.0, the `Time.MarshalJSON()` method now returns millisecond timestamps as numbers by default, rather than unquoted strings. This ensures valid JSON generation when Time values are embedded in larger JSON structures.
+
+You can revert to the legacy format (properly quoted time strings) by setting the environment variable `LUNO_TIME_LEGACY_FORMAT=true` in your application.
+
+For more details and migration guidance, please see:
+- [CHANGELOG.md](./CHANGELOG.md)
+- [Example migration code](./_examples/time_migration/main.go)
+
 ## Authentication
 
 Please visit the [Settings](https://www.luno.com/wallet/settings/api_keys) page

--- a/README.md
+++ b/README.md
@@ -43,8 +43,11 @@ import (
 
 func main() {
 	lunoClient := luno.NewClient()
-	lunoClient.SetAuth("<id>", "<secret>")
-
+	err := lunoClient.SetAuth("<id>", "<secret>")
+	if err != nil {
+		log.Fatal(err)
+	}
+	
 	req := luno.GetOrderBookRequest{Pair: "XBTZAR"}
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(10*time.Second))
 	defer cancel()

--- a/_examples/time_migration/timehelper.go
+++ b/_examples/time_migration/timehelper.go
@@ -2,7 +2,7 @@ package main
 
 // Example showing how to handle both old and new Time format
 //
-// Note: Starting with v0.0.34, you can control the format by setting the
+// Note: Starting with v0.1.0, you can control the format by setting the
 // environment variable LUNO_TIME_LEGACY_FORMAT=true to use the legacy string format.
 // This example shows how to handle both formats if you're consuming data from
 // different versions or configurations of the library.

--- a/_examples/time_migration/timehelper.go
+++ b/_examples/time_migration/timehelper.go
@@ -1,0 +1,59 @@
+package main
+
+// Example showing how to handle both old and new Time format
+//
+// Note: Starting with v0.0.34, you can control the format by setting the
+// environment variable LUNO_TIME_LEGACY_FORMAT=true to use the legacy string format.
+// This example shows how to handle both formats if you're consuming data from
+// different versions or configurations of the library.
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// TimeCompatHelper helps with migrating from old Time string format to new millisecond format
+func TimeCompatHelper(timeField json.RawMessage) (time.Time, error) {
+	// Try to parse as millisecond timestamp (new format)
+	var ms int64
+	err := json.Unmarshal(timeField, &ms)
+	if err == nil {
+		return time.Unix(0, ms*1e6), nil
+	}
+
+	// Try to parse as string (old format)
+	var timeStr string
+	err = json.Unmarshal(timeField, &timeStr)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to parse time: %w", err)
+	}
+
+	// Try parsing as time string
+	t, err := time.Parse(time.RFC3339, timeStr)
+	if err == nil {
+		return t, nil
+	}
+
+	// Try various other time formats...
+	layouts := []string{
+		time.ANSIC,
+		time.UnixDate,
+		time.RubyDate,
+		time.RFC822,
+		time.RFC822Z,
+		time.RFC850,
+		time.RFC1123,
+		time.RFC1123Z,
+		"2006-01-02 15:04:05 -0700 MST",
+	}
+
+	for _, layout := range layouts {
+		t, err := time.Parse(layout, timeStr)
+		if err == nil {
+			return t, nil
+		}
+	}
+
+	return time.Time{}, fmt.Errorf("could not parse time from: %s", timeStr)
+}

--- a/_examples/time_migration/timehelper_test.go
+++ b/_examples/time_migration/timehelper_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ExampleTimeCompatHelper demonstrates how to use TimeCompatHelper to handle both
+// the old string format and new millisecond format for timestamps.
+func ExampleTimeCompatHelper() {
+	// Example with new format (milliseconds)
+	newFormat := []byte(`{"timestamp":1621234567890}`)
+
+	// Example with old format (string)
+	oldFormat := []byte(`{"timestamp":"2021-05-17 12:34:56 +0000 UTC"}`)
+
+	// Handle both formats
+	for _, data := range [][]byte{newFormat, oldFormat} {
+		var result map[string]json.RawMessage
+		if err := json.Unmarshal(data, &result); err != nil {
+			panic(err)
+		}
+
+		t, err := TimeCompatHelper(result["timestamp"])
+		if err != nil {
+			panic(err)
+		}
+
+		fmt.Printf("Parsed time: %v\n", t.UTC().Format("2006-01-02 15:04:05.999999999 -0700 MST"))
+	}
+	// Output:
+	// Parsed time: 2021-05-17 06:56:07.89 +0000 UTC
+	// Parsed time: 2021-05-17 12:34:56 +0000 UTC
+}

--- a/time.go
+++ b/time.go
@@ -21,7 +21,11 @@ func (t *Time) UnmarshalJSON(b []byte) error {
 }
 
 func (t Time) MarshalJSON() ([]byte, error) {
-	return []byte(t.String()), nil
+	if time.Time(t).IsZero() {
+		return []byte("0"), nil
+	}
+	ms := time.Time(t).UnixNano() / 1e6
+	return []byte(strconv.FormatInt(ms, 10)), nil
 }
 
 func (t Time) String() string {

--- a/time.go
+++ b/time.go
@@ -1,6 +1,7 @@
 package luno
 
 import (
+	"os"
 	"strconv"
 	"time"
 )
@@ -21,9 +22,21 @@ func (t *Time) UnmarshalJSON(b []byte) error {
 }
 
 func (t Time) MarshalJSON() ([]byte, error) {
+	// Check if LUNO_TIME_LEGACY_FORMAT environment variable is set to control
+	// whether to use the original string format (when set to "true")
+	// or the new millisecond timestamp format (default)
+	useLegacyFormat := os.Getenv("LUNO_TIME_LEGACY_FORMAT") == "true"
+
 	if time.Time(t).IsZero() {
 		return []byte("0"), nil
 	}
+
+	if useLegacyFormat {
+		// Return properly quoted string in the original format
+		return []byte(`"` + time.Time(t).String() + `"`), nil
+	}
+
+	// Return millisecond timestamp (numeric format)
 	ms := time.Time(t).UnixNano() / 1e6
 	return []byte(strconv.FormatInt(ms, 10)), nil
 }

--- a/time_test.go
+++ b/time_test.go
@@ -1,6 +1,7 @@
 package luno_test
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -59,19 +60,20 @@ func TestTimeMarshalJSON(t *testing.T) {
 	}
 
 	now := time.Now()
+	msNow := now.UnixNano() / 1e6
 
 	testCases := []testCase{
 		{
 			in:  luno.Time{},
-			exp: time.Time{}.String(),
+			exp: "0",
 		},
 		{
 			in:  luno.Time(now),
-			exp: now.String(),
+			exp: strconv.FormatInt(msNow, 10),
 		},
 		{
 			in:  luno.Time(time.Date(2006, 1, 2, 3, 4, 5, 999, time.UTC)),
-			exp: time.Date(2006, 1, 2, 3, 4, 5, 999, time.UTC).String(),
+			exp: strconv.FormatInt(time.Date(2006, 1, 2, 3, 4, 5, 999, time.UTC).UnixNano()/1e6, 10),
 		},
 	}
 

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package luno
 
-const Version = "0.0.33"
+const Version = "0.1.0"
 
 // vi: ft=go


### PR DESCRIPTION
### Fix
- Marshalling of zero-value luno.Time
  - This will be a breaking change, so will bump minor version (since we're still pre v1 officially)
  - Provided way of preserving existing behaviour with `LUNO_TIME_LEGACY_FORMAT` env var
  - Provided helper function for dealing with times that are potentially from old and new formats

### Changed
- Example in README to not ignore error


We fail to marshal payloads like this from ListOrders:
```json
{
  "base": "0.00",
  "completed_timestamp": 0,
  "counter": "0.00",
  "creation_timestamp": 1746473170125,
  "expiration_timestamp": 0,
  "fee_base": "0.00",
  "fee_counter": "0.00",
  "limit_price": "1459.00",
  "limit_volume": "0.001",
  "order_id": "<order_id>",
  "pair": "ETHGBP",
  "state": "PENDING",
  "time_in_force": "GTC",
  "type": "ASK"
},
{
  "base": "0.00",
  "completed_timestamp": 0,
  "counter": "0.00",
  "creation_timestamp": 1746473166372,
  "expiration_timestamp": 0,
  "fee_base": "0.00",
  "fee_counter": "0.00",
  "limit_price": "1459.00",
  "limit_volume": "0.001",
  "order_id": "<order_id>",
  "pair": "ETHGBP",
  "state": "PENDING",
  "time_in_force": "GTC",
  "type": "ASK"
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a migration helper and example to assist users in handling both legacy and new time formats in JSON serialization.
  - Introduced a changelog to document notable project changes and migration guidance.

- **Bug Fixes**
  - Improved JSON serialization of time values to default to numeric millisecond timestamps, ensuring valid JSON embedding.

- **Documentation**
  - Updated README with details on the breaking change to time serialization and migration options.

- **Tests**
  - Enhanced tests to verify correct handling of both legacy and new time formats.

- **Chores**
  - Updated version to 0.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->