### PR TITLE
time: Handle different time formats when unmarshalling

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ import (
 
 func main() {
 	lunoClient := luno.NewClient()
-	lunoClient.SetAuth("<id>", "<secret>")
+	err := lunoClient.SetAuth("<id>", "<secret>")
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	req := luno.GetOrderBookRequest{Pair: "XBTZAR"}
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(10*time.Second))

--- a/time.go
+++ b/time.go
@@ -1,6 +1,7 @@
 package luno
 
 import (
+	"encoding/json"
 	"strconv"
 	"time"
 )
@@ -8,20 +9,55 @@ import (
 type Time time.Time
 
 func (t *Time) UnmarshalJSON(b []byte) error {
-	i, err := strconv.ParseInt(string(b), 10, 64)
-	if err != nil {
-		return err
-	}
-	if i == 0 {
+	// Handle null case
+	if string(b) == "null" || len(b) == 0 {
 		*t = Time{}
 		return nil
 	}
-	*t = Time(time.Unix(0, i*1e6))
-	return nil
+
+	// Try to parse as integer (milliseconds since epoch)
+	i, err := strconv.ParseInt(string(b), 10, 64)
+	if err == nil {
+		if i == 0 {
+			*t = Time{}
+			return nil
+		}
+		*t = Time(time.Unix(0, i*1e6))
+		return nil
+	}
+
+	// Try to parse as string
+	var timeStr string
+	if err := json.Unmarshal(b, &timeStr); err != nil {
+		return err
+	}
+
+	// Try RFC3339 format
+	parsed, err := time.Parse(time.RFC3339, timeStr)
+	if err == nil {
+		*t = Time(parsed)
+		return nil
+	}
+
+	// Try Go's default format
+	parsed, err = time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", timeStr)
+	if err == nil {
+		*t = Time(parsed)
+		return nil
+	}
+
+	return err
 }
 
 func (t Time) MarshalJSON() ([]byte, error) {
-	return []byte(t.String()), nil
+	// Omit if zero
+	if time.Time(t).IsZero() {
+		return []byte("null"), nil
+	}
+
+	// Format as RFC3339 string
+	timeStr := time.Time(t).Format(time.RFC3339)
+	return json.Marshal(timeStr)
 }
 
 func (t Time) String() string {

--- a/time_test.go
+++ b/time_test.go
@@ -16,11 +16,12 @@ func TestTimeUnmarshalJSON(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			err: true,
+			in:  []byte("null"),
+			exp: luno.Time{},
 		},
 		{
 			in:  []byte{},
-			err: true,
+			exp: luno.Time{},
 		},
 		{
 			in:  []byte("abc"),
@@ -33,6 +34,14 @@ func TestTimeUnmarshalJSON(t *testing.T) {
 		{
 			in:  []byte("-123456"),
 			exp: luno.Time(time.Unix(0, -123456e6)),
+		},
+		{
+			in:  []byte(`"2006-01-02T15:04:05Z"`),
+			exp: luno.Time(time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC)),
+		},
+		{
+			in:  []byte(`"2006-01-02 15:04:05 +0000 UTC"`),
+			exp: luno.Time(time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC)),
 		},
 	}
 
@@ -58,20 +67,16 @@ func TestTimeMarshalJSON(t *testing.T) {
 		exp string
 	}
 
-	now := time.Now()
+	date := time.Date(2006, 1, 2, 3, 4, 5, 0, time.UTC)
 
 	testCases := []testCase{
 		{
 			in:  luno.Time{},
-			exp: time.Time{}.String(),
+			exp: "null",
 		},
 		{
-			in:  luno.Time(now),
-			exp: now.String(),
-		},
-		{
-			in:  luno.Time(time.Date(2006, 1, 2, 3, 4, 5, 999, time.UTC)),
-			exp: time.Date(2006, 1, 2, 3, 4, 5, 999, time.UTC).String(),
+			in:  luno.Time(date),
+			exp: `"2006-01-02T03:04:05Z"`,
 		},
 	}
 

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package luno
 
-const Version = "0.0.33"
+const Version = "0.0.34"
 
 // vi: ft=go


### PR DESCRIPTION
### Changed
- Handle different time formats when unmarshalling
  - This can occur if we are unmarsalling responses from the API with the SDK, and the marshalling them to different API calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of JSON time values to support multiple formats, including null and empty values, ensuring consistent and robust parsing and serialisation.
- **Documentation**
	- Updated the README example to include error handling for authentication setup.
- **Tests**
	- Enhanced tests to cover additional valid JSON time inputs and updated expectations for marshalled and unmarshalled values.
- **Chores**
	- Updated the version number to 0.0.34.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->