### PR TITLE
api: Add GetAccountMarkets for per-account market access

### DIFF
--- a/api.go
+++ b/api.go
@@ -1393,6 +1393,20 @@ func (cl *Client) Markets(ctx context.Context, req *MarketsRequest) (*MarketsRes
 	return &res, nil
 }
 
+// GetAccountMarkets makes a call to GET /api/exchange/1/account_markets.
+//
+// Returns the list of markets that the authenticated account is permitted to trade.
+//
+// Permissions required: <code>Perm_R_Orders</code>
+func (cl *Client) GetAccountMarkets(ctx context.Context, req *GetAccountMarketsRequest) (*GetAccountMarketsResponse, error) {
+	var res GetAccountMarketsResponse
+	err := cl.do(ctx, "GET", "/api/exchange/1/account_markets", req, &res, true)
+	if err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
 // MoveRequest is the request struct for Move.
 type MoveRequest struct {
 	// Amount to transfer. Must be positive.

--- a/types.go
+++ b/types.go
@@ -119,6 +119,14 @@ const (
 	KindTransfer Kind = "TRANSFER"
 )
 
+// GetAccountMarketsRequest is the request struct for GetAccountMarkets.
+type GetAccountMarketsRequest struct{}
+
+// GetAccountMarketsResponse is the response struct for GetAccountMarkets.
+type GetAccountMarketsResponse struct {
+	Markets []MarketInfo `json:"markets"`
+}
+
 type MarketInfo struct {
 	// Base currency code
 	BaseCurrency string `json:"base_currency"`


### PR DESCRIPTION
## Summary

- Adds `GetAccountMarkets()` method to the Luno Go client
- Calls `GET /api/exchange/1/account_markets` — a new endpoint that returns only the markets the authenticated account is permitted to trade
- Mirrors the existing `Markets()` method but passes `true` for the auth flag (authentication is required)

## Why a dedicated method

The existing `Markets()` method calls `GET /api/exchange/1/markets`, which lists globally visible markets and does not require authentication. Account-scoped market access is a different concept — it requires auth and returns a user-specific subset — so it warrants its own method rather than a parameter on the existing one.

## Test plan

- [ ] Verify `GetAccountMarkets` compiles and matches the endpoint's request/response shape
- [ ] Integration test against the API once the server-side change is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new authenticated API endpoint enabling users to retrieve and view market information associated with their accounts. This endpoint provides access to comprehensive market data linked to individual user accounts through secure authenticated API requests, improving overall visibility of market information relevant to account activity, trading patterns, portfolio composition, and current market holdings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->