### PR TITLE
ci: test latest Go only and bump go.mod to 1.26.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,6 @@ on:
 jobs:
 
   build:
-    strategy:
-      matrix:
-        go: [ '1.24', '1' ]
     runs-on: ubuntu-latest
 
     steps:
@@ -21,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ matrix.go }}
+          go-version: '1'
 
       - name: Vet
         run: go vet ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1'
+          go-version-file: 'go.mod'
 
       - name: Vet
         run: go vet ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/luno/luno-go
 
-go 1.24.0
+go 1.26.0
 
 require (
 	github.com/gorilla/websocket v1.5.3


### PR DESCRIPTION
Simplify the CI test matrix to only test with the latest Go (`'1'`), and bump the `go` directive in `go.mod` to `1.26.0`.

Testing multiple Go versions caused flaky failures whenever we bumped deps ahead of the oldest supported version. Since we don't commit to long-term compatibility with older Go releases, there's no value in the matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated minimum Go version requirement from 1.24.0 to 1.26.0
  * Simplified continuous integration testing pipeline

<!-- end of auto-generated comment: release notes by coderabbit.ai -->