### PR TITLE
Regenerate SDK from latest Luno spec

### DIFF
--- a/api.go
+++ b/api.go
@@ -60,6 +60,66 @@ func (cl *Client) CancelWithdrawal(ctx context.Context, req *CancelWithdrawalReq
 	return &res, nil
 }
 
+// ConvertRequest is the request struct for Convert.
+type ConvertRequest struct {
+	// Amount to convert from the source account. Must be positive.
+	//
+	// required: true
+	Amount decimal.Decimal `json:"amount" url:"amount"`
+
+	// A unique key to prevent duplicate conversions. If a conversion with the same key
+	// already exists and completed successfully, the original result is returned.
+	// Use a new key to retry a failed conversion.
+	//
+	// required: true
+	IdempotencyKey string `json:"idempotency_key" url:"idempotency_key"`
+
+	// The account to convert funds from.
+	//
+	// required: true
+	SourceAccountId int64 `json:"source_account_id" url:"source_account_id"`
+
+	// The account to receive the converted funds.
+	//
+	// required: true
+	TargetAccountId int64 `json:"target_account_id" url:"target_account_id"`
+}
+
+// ConvertResponse is the response struct for Convert.
+type ConvertResponse struct {
+	// Amount received in the target account after conversion
+	ConvertedAmount decimal.Decimal `json:"converted_amount"`
+
+	// Conversion unique identifier
+	Id string `json:"id"`
+
+	// Balance of the source account after the conversion
+	SourceAccountBalance decimal.Decimal `json:"source_account_balance"`
+
+	// Currency of the source account
+	SourceCurrency string `json:"source_currency"`
+
+	// Balance of the target account after the conversion
+	TargetAccountBalance decimal.Decimal `json:"target_account_balance"`
+
+	// Currency of the target account
+	TargetCurrency string `json:"target_currency"`
+}
+
+// Convert makes a call to POST /api/exchange/1/convert.
+//
+// Instantly convert between two currencies. Only conversions between ZAR and ZARU are supported. Conversions will be done at a 1:1 rate.
+//
+// Permissions required: <code>MP_Transfers</code>
+func (cl *Client) Convert(ctx context.Context, req *ConvertRequest) (*ConvertResponse, error) {
+	var res ConvertResponse
+	err := cl.do(ctx, "POST", "/api/exchange/1/convert", req, &res, true)
+	if err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
 // CreateAccountRequest is the request struct for CreateAccount.
 type CreateAccountRequest struct {
 	// The currency code for the Account you want to create.  Please see the Currency section for a detailed list of currencies supported by the Luno platform.
@@ -147,11 +207,14 @@ type CreateFundingAddressRequest struct {
 	// required: true
 	Asset string `json:"asset" url:"asset"`
 
-	// An optional account_id to assign the new Receive Address too
+	// An optional account_id to assign the new Receive Address to. If omitted, Receive Address will be assigned to the default account.
 	AccountId int64 `json:"account_id" url:"account_id"`
 
 	// An optional name for the new Receive Address
 	Name string `json:"name" url:"name"`
+
+	// The blockchain network to use for the transaction. If none is provided the default network is used
+	Network int64 `json:"network" url:"network"`
 }
 
 // CreateFundingAddressResponse is the response struct for CreateFundingAddress.
@@ -162,6 +225,7 @@ type CreateFundingAddressResponse struct {
 	Asset            string          `json:"asset"`
 	AssignedAt       Time            `json:"assigned_at"`
 	Name             string          `json:"name"`
+	Network          int64           `json:"network"`
 	QrCodeUri        string          `json:"qr_code_uri"`
 	ReceiveFee       decimal.Decimal `json:"receive_fee"`
 	TotalReceived    decimal.Decimal `json:"total_received"`
@@ -215,6 +279,10 @@ type CreateWithdrawalRequest struct {
 	// For internal use.
 	// Deprecated: We don't allow custom references and will remove this soon.
 	Reference string `json:"reference" url:"reference"`
+
+	// Optional source account ID representing the account from which the Withdrawal will be made,
+	// fall back to the default account if not provided.
+	SourceAccountId int64 `json:"source_account_id" url:"source_account_id"`
 }
 
 // CreateWithdrawalResponse is the response struct for CreateWithdrawal.
@@ -366,8 +434,23 @@ type GetFeeInfoRequest struct {
 
 // GetFeeInfoResponse is the response struct for GetFeeInfo.
 type GetFeeInfoResponse struct {
-	MakerFee        string `json:"maker_fee"`
-	TakerFee        string `json:"taker_fee"`
+	// Deprecated: Use maker_fee_buy or maker_fee_sell
+	MakerFee string `json:"maker_fee"`
+
+	// Fee rate for orders matching as maker buy orders
+	MakerFeeBuy string `json:"maker_fee_buy"`
+
+	// Fee rate for orders matching as maker sell orders
+	MakerFeeSell string `json:"maker_fee_sell"`
+
+	// Deprecated: Use taker_fee_buy or taker_fee_sell
+	TakerFee string `json:"taker_fee"`
+
+	// Fee rate for orders matching as taker buy orders
+	TakerFeeBuy string `json:"taker_fee_buy"`
+
+	// Fee rate for orders matching as taker sell orders
+	TakerFeeSell    string `json:"taker_fee_sell"`
 	ThirtyDayVolume string `json:"thirty_day_volume"`
 }
 
@@ -395,6 +478,9 @@ type GetFundingAddressRequest struct {
 	// Specific cryptocurrency address to retrieve. If not provided, the
 	// default address will be used.
 	Address string `json:"address" url:"address"`
+
+	// The blockchain network to use for the transaction. If none is provided the default network is used
+	Network int64 `json:"network" url:"network"`
 }
 
 // GetFundingAddressResponse is the response struct for GetFundingAddress.
@@ -405,6 +491,7 @@ type GetFundingAddressResponse struct {
 	Asset            string          `json:"asset"`
 	AssignedAt       Time            `json:"assigned_at"`
 	Name             string          `json:"name"`
+	Network          int64           `json:"network"`
 	QrCodeUri        string          `json:"qr_code_uri"`
 	ReceiveFee       decimal.Decimal `json:"receive_fee"`
 	TotalReceived    decimal.Decimal `json:"total_received"`
@@ -468,6 +555,10 @@ type GetMoveResponse struct {
 	// balance.<br>
 	// <code>FAILED</code> The move has failed. There could be many reasons for this but the most likely is that the
 	// debit account doesn't have enough available funds to move.<br>
+	// CREATED MoveStatusCreated
+	// MOVING MoveStatusMoving
+	// SUCCESSFUL MoveStatusSuccessful
+	// FAILED MoveStatusFailed
 	Status Status `json:"status"`
 
 	// Unix time the move was last updated, in milliseconds
@@ -713,6 +804,8 @@ type GetOrderV2Response struct {
 	// The intention of the order, whether to buy or sell funds in the market.
 	//
 	// You can use this to determine the flow of funds in the order.
+	// BUY OrderSideBuy
+	// SELL OrderSideSell
 	Side Side `json:"side"`
 
 	// The current state of the order
@@ -723,9 +816,14 @@ type GetOrderV2Response struct {
 	// have taken place but the order is not filled yet.<br>
 	// <code>COMPLETE</code> The order is no longer in the order book. It has
 	// been settled/filled or has been cancelled.
+	// AWAITING OrderStatusAwaiting
+	// PENDING OrderStatusPending
+	// COMPLETE OrderStatusComplete
 	Status Status `json:"status"`
 
 	// Direction to trigger the order
+	// ABOVE StopDirectionAbove
+	// BELOW StopDirectionBelow
 	StopDirection StopDirection `json:"stop_direction"`
 
 	// Price to trigger the order
@@ -740,6 +838,9 @@ type GetOrderV2Response struct {
 	TimeInForce string `json:"time_in_force"`
 
 	// The order type
+	// LIMIT OrderTypeLimit
+	// MARKET OrderTypeMarket
+	// STOP_LIMIT OrderTypeStopLimit
 	Type Type `json:"type"`
 }
 
@@ -823,6 +924,8 @@ type GetOrderV3Response struct {
 	// The intention of the order, whether to buy or sell funds in the market.
 	//
 	// You can use this to determine the flow of funds in the order.
+	// BUY OrderSideBuy
+	// SELL OrderSideSell
 	Side Side `json:"side"`
 
 	// The current state of the order
@@ -833,9 +936,14 @@ type GetOrderV3Response struct {
 	// have taken place but the order is not filled yet.<br>
 	// <code>COMPLETE</code> The order is no longer in the order book. It has
 	// been settled/filled or has been cancelled.
+	// AWAITING OrderStatusAwaiting
+	// PENDING OrderStatusPending
+	// COMPLETE OrderStatusComplete
 	Status Status `json:"status"`
 
 	// Direction to trigger the order
+	// ABOVE StopDirectionAbove
+	// BELOW StopDirectionBelow
 	StopDirection StopDirection `json:"stop_direction"`
 
 	// Price to trigger the order
@@ -850,6 +958,9 @@ type GetOrderV3Response struct {
 	TimeInForce string `json:"time_in_force"`
 
 	// The order type
+	// LIMIT OrderTypeLimit
+	// MARKET OrderTypeMarket
+	// STOP_LIMIT OrderTypeStopLimit
 	Type Type `json:"type"`
 }
 
@@ -991,6 +1102,28 @@ type GetWithdrawalResponse struct {
 func (cl *Client) GetWithdrawal(ctx context.Context, req *GetWithdrawalRequest) (*GetWithdrawalResponse, error) {
 	var res GetWithdrawalResponse
 	err := cl.do(ctx, "GET", "/api/1/withdrawals/{id}", req, &res, true)
+	if err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+// LinkedRequest is the request struct for Linked.
+type LinkedRequest struct {
+}
+
+// LinkedResponse is the response struct for Linked.
+type LinkedResponse struct {
+	// List of linked user accounts configured for multi-access
+	Users []LinkedUser `json:"users"`
+}
+
+// Linked makes a call to GET /api/1/users/linked.
+//
+// Returns a list of users linked to this API key with additional permissions.
+func (cl *Client) Linked(ctx context.Context, req *LinkedRequest) (*LinkedResponse, error) {
+	var res LinkedResponse
+	err := cl.do(ctx, "GET", "/api/1/users/linked", req, &res, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1411,10 +1544,6 @@ type MoveRequest struct {
 	DebitAccountId int64 `json:"debit_account_id" url:"debit_account_id"`
 
 	// Client move ID.
-	// May only contain alphanumeric (0-9, a-z, or A-Z) and special characters (_ ; , . -). Maximum length: 255.
-	// It will be available in read endpoints, so you can use it to avoid duplicate moves between the same accounts.
-	// Values must be unique across all your successful calls of this endpoint; trying to create a move request
-	// with the same `client_move_id` as one of your past move requests will result in a HTTP 409 Conflict response.
 	ClientMoveId string `json:"client_move_id" url:"client_move_id"`
 }
 
@@ -1432,6 +1561,10 @@ type MoveResponse struct {
 	// balance.<br>
 	// <code>FAILED</code> The move has failed. There could be many reasons for this but the most likely is that the
 	// debit account doesn't have enough available funds to move.<br>
+	// CREATED MoveStatusCreated
+	// MOVING MoveStatusMoving
+	// SUCCESSFUL MoveStatusSuccessful
+	// FAILED MoveStatusFailed
 	Status Status `json:"status"`
 }
 
@@ -1480,10 +1613,6 @@ type PostLimitOrderRequest struct {
 	BaseAccountId int64 `json:"base_account_id" url:"base_account_id"`
 
 	// Client order ID.
-	// May only contain alphanumeric (0-9, a-z, or A-Z) and special characters (_ ; , . -). Maximum length: 255.
-	// It will be available in read endpoints, so you can use it to reconcile Luno with your internal system.
-	// Values must be unique across all your successful order creation endpoint calls; trying to create an order
-	// with the same `client_order_id` as one of your past orders will result in a HTTP 409 Conflict response.
 	ClientOrderId string `json:"client_order_id" url:"client_order_id"`
 
 	// The counter currency Account to use in the trade.
@@ -1568,10 +1697,6 @@ type PostMarketOrderRequest struct {
 	BaseVolume decimal.Decimal `json:"base_volume" url:"base_volume"`
 
 	// Client order ID.
-	// May only contain alphanumeric (0-9, a-z, or A-Z) and special characters (_ ; , . -). Maximum length: 255.
-	// It will be available in read endpoints, so you can use it to reconcile Luno with your internal system.
-	// Values must be unique across all your successful order creation endpoint calls; trying to create an order
-	// with the same `client_order_id` as one of your past orders will result in a HTTP 409 Conflict response.
 	ClientOrderId string `json:"client_order_id" url:"client_order_id"`
 
 	// The counter currency account to use in the trade.
@@ -1671,6 +1796,9 @@ type SendRequest struct {
 	// Message to send to the recipient.
 	// This is only relevant when sending to an email address.
 	Message string `json:"message" url:"message"`
+
+	// The blockchain network to use for the transaction. If none is provided the default network is used
+	Network int64 `json:"network" url:"network"`
 }
 
 // SendResponse is the response struct for Send.
@@ -1738,6 +1866,33 @@ type SendFeeResponse struct {
 func (cl *Client) SendFee(ctx context.Context, req *SendFeeRequest) (*SendFeeResponse, error) {
 	var res SendFeeResponse
 	err := cl.do(ctx, "GET", "/api/1/send_fee", req, &res, true)
+	if err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+// SendNetworksRequest is the request struct for SendNetworks.
+type SendNetworksRequest struct {
+	// Currency to send
+	//
+	// required: true
+	Currency string `json:"currency" url:"currency"`
+}
+
+// SendNetworksResponse is the response struct for SendNetworks.
+type SendNetworksResponse struct {
+	Networks []SendNetwork `json:"networks"`
+}
+
+// SendNetworks makes a call to GET /api/1/send/networks.
+//
+// Returns a list of supported send networks for the user and currency. The network identifiers are to be used in the `POST /api/1/send` call.
+//
+// Permissions required: <code>MP_None</code>
+func (cl *Client) SendNetworks(ctx context.Context, req *SendNetworksRequest) (*SendNetworksResponse, error) {
+	var res SendNetworksResponse
+	err := cl.do(ctx, "GET", "/api/1/send/networks", req, &res, true)
 	if err != nil {
 		return nil, err
 	}

--- a/api.go
+++ b/api.go
@@ -1108,21 +1108,26 @@ func (cl *Client) GetWithdrawal(ctx context.Context, req *GetWithdrawalRequest) 
 	return &res, nil
 }
 
-// LinkedRequest is the request struct for Linked.
-type LinkedRequest struct {
+// LinkedUsersRequest is the request struct for LinkedUsers.
+type LinkedUsersRequest struct {
+	// Limit to this many users.
+	Limit int64 `json:"limit" url:"limit"`
+
+	// Page through records
+	Offset int64 `json:"offset" url:"offset"`
 }
 
-// LinkedResponse is the response struct for Linked.
-type LinkedResponse struct {
+// LinkedUsersResponse is the response struct for LinkedUsers.
+type LinkedUsersResponse struct {
 	// List of linked user accounts configured for multi-access
 	Users []LinkedUser `json:"users"`
 }
 
-// Linked makes a call to GET /api/1/users/linked.
+// LinkedUsers makes a call to GET /api/1/users/linked.
 //
 // Returns a list of users linked to this API key with additional permissions.
-func (cl *Client) Linked(ctx context.Context, req *LinkedRequest) (*LinkedResponse, error) {
-	var res LinkedResponse
+func (cl *Client) LinkedUsers(ctx context.Context, req *LinkedUsersRequest) (*LinkedUsersResponse, error) {
+	var res LinkedUsersResponse
 	err := cl.do(ctx, "GET", "/api/1/users/linked", req, &res, true)
 	if err != nil {
 		return nil, err

--- a/api.go
+++ b/api.go
@@ -1123,7 +1123,7 @@ type LinkedResponse struct {
 // Returns a list of users linked to this API key with additional permissions.
 func (cl *Client) Linked(ctx context.Context, req *LinkedRequest) (*LinkedResponse, error) {
 	var res LinkedResponse
-	err := cl.do(ctx, "GET", "/api/1/users/linked", req, &res, false)
+	err := cl.do(ctx, "GET", "/api/1/users/linked", req, &res, true)
 	if err != nil {
 		return nil, err
 	}

--- a/convert_test.go
+++ b/convert_test.go
@@ -1,0 +1,79 @@
+package luno
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/luno/luno-go/decimal"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvert(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/api/exchange/1/convert", r.URL.Path)
+
+		require.NoError(t, r.ParseForm())
+		require.Equal(t, "100", r.Form.Get("amount"))
+		require.Equal(t, "12345", r.Form.Get("source_account_id"))
+		require.Equal(t, "12346", r.Form.Get("target_account_id"))
+		require.Equal(t, "convert-abc123", r.Form.Get("idempotency_key"))
+
+		_, _, ok := r.BasicAuth()
+		require.True(t, ok, "Convert must send credentials")
+
+		_ = json.NewEncoder(w).Encode(ConvertResponse{
+			Id:                   "conv-1",
+			SourceCurrency:       "ZARU",
+			TargetCurrency:       "ZAR",
+			ConvertedAmount:      decimal.NewFromInt64(100),
+			SourceAccountBalance: decimal.NewFromInt64(900),
+			TargetAccountBalance: decimal.NewFromInt64(1100),
+		})
+	}))
+	defer srv.Close()
+
+	cl := NewClient()
+	cl.SetBaseURL(srv.URL)
+	require.NoError(t, cl.SetAuth("key-id", "key-secret"))
+
+	res, err := cl.Convert(context.Background(), &ConvertRequest{
+		Amount:          decimal.NewFromInt64(100),
+		SourceAccountId: 12345,
+		TargetAccountId: 12346,
+		IdempotencyKey:  "convert-abc123",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "conv-1", res.Id)
+	require.Equal(t, "ZARU", res.SourceCurrency)
+	require.Equal(t, "ZAR", res.TargetCurrency)
+	require.Equal(t, "100", res.ConvertedAmount.String())
+	require.Equal(t, "900", res.SourceAccountBalance.String())
+	require.Equal(t, "1100", res.TargetAccountBalance.String())
+}
+
+func TestConvertError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"missing idempotency key","error_code":"ErrMissingIdempotencyKey"}`))
+	}))
+	defer srv.Close()
+
+	cl := NewClient()
+	cl.SetBaseURL(srv.URL)
+	require.NoError(t, cl.SetAuth("key-id", "key-secret"))
+
+	_, err := cl.Convert(context.Background(), &ConvertRequest{
+		Amount:          decimal.NewFromInt64(100),
+		SourceAccountId: 12345,
+		TargetAccountId: 12346,
+	})
+	require.Error(t, err)
+
+	var apiErr Error
+	require.ErrorAs(t, err, &apiErr)
+	require.Equal(t, "ErrMissingIdempotencyKey", apiErr.ErrCode())
+}

--- a/linked_test.go
+++ b/linked_test.go
@@ -10,15 +10,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLinked(t *testing.T) {
+func TestLinkedUsers(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodGet, r.Method)
 		require.Equal(t, "/api/1/users/linked", r.URL.Path)
 
 		_, _, ok := r.BasicAuth()
-		require.True(t, ok, "Linked must send credentials")
+		require.True(t, ok, "LinkedUsers must send credentials")
 
-		_ = json.NewEncoder(w).Encode(LinkedResponse{
+		require.NoError(t, r.ParseForm())
+		require.Equal(t, "50", r.Form.Get("limit"))
+		require.Equal(t, "10", r.Form.Get("offset"))
+
+		_ = json.NewEncoder(w).Encode(LinkedUsersResponse{
 			Users: []LinkedUser{
 				{
 					CreatedAt:   1700000000000,
@@ -41,7 +45,10 @@ func TestLinked(t *testing.T) {
 	cl.SetBaseURL(srv.URL)
 	require.NoError(t, cl.SetAuth("key-id", "key-secret"))
 
-	res, err := cl.Linked(context.Background(), &LinkedRequest{})
+	res, err := cl.LinkedUsers(context.Background(), &LinkedUsersRequest{
+		Limit:  50,
+		Offset: 10,
+	})
 	require.NoError(t, err)
 	require.Len(t, res.Users, 2)
 

--- a/linked_test.go
+++ b/linked_test.go
@@ -1,0 +1,55 @@
+package luno
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinked(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/api/1/users/linked", r.URL.Path)
+
+		_, _, ok := r.BasicAuth()
+		require.True(t, ok, "Linked must send credentials")
+
+		_ = json.NewEncoder(w).Encode(LinkedResponse{
+			Users: []LinkedUser{
+				{
+					CreatedAt:   1700000000000,
+					Label:       "alice",
+					Permissions: []string{"Perm_R_Balance", "Perm_R_Orders"},
+					UserId:      "u-1",
+				},
+				{
+					CreatedAt:   1700000001000,
+					Label:       "bob",
+					Permissions: []string{"Perm_R_Balance"},
+					UserId:      "u-2",
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	cl := NewClient()
+	cl.SetBaseURL(srv.URL)
+	require.NoError(t, cl.SetAuth("key-id", "key-secret"))
+
+	res, err := cl.Linked(context.Background(), &LinkedRequest{})
+	require.NoError(t, err)
+	require.Len(t, res.Users, 2)
+
+	require.Equal(t, "u-1", res.Users[0].UserId)
+	require.Equal(t, "alice", res.Users[0].Label)
+	require.Equal(t, int64(1700000000000), res.Users[0].CreatedAt)
+	require.Equal(t, []string{"Perm_R_Balance", "Perm_R_Orders"}, res.Users[0].Permissions)
+
+	require.Equal(t, "u-2", res.Users[1].UserId)
+	require.Equal(t, []string{"Perm_R_Balance"}, res.Users[1].Permissions)
+}

--- a/send_networks_test.go
+++ b/send_networks_test.go
@@ -1,0 +1,50 @@
+package luno
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendNetworks(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/api/1/send/networks", r.URL.Path)
+
+		require.NoError(t, r.ParseForm())
+		require.Equal(t, "ETH", r.Form.Get("currency"))
+
+		_, _, ok := r.BasicAuth()
+		require.True(t, ok, "SendNetworks must send credentials")
+
+		_ = json.NewEncoder(w).Encode(SendNetworksResponse{
+			Networks: []SendNetwork{
+				{Id: 0, Name: "Ethereum", NativeCurrency: "ETH"},
+				{Id: 1, Name: "Polygon", NativeCurrency: "MATIC"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	cl := NewClient()
+	cl.SetBaseURL(srv.URL)
+	require.NoError(t, cl.SetAuth("key-id", "key-secret"))
+
+	res, err := cl.SendNetworks(context.Background(), &SendNetworksRequest{
+		Currency: "ETH",
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Networks, 2)
+
+	require.Equal(t, int64(0), res.Networks[0].Id)
+	require.Equal(t, "Ethereum", res.Networks[0].Name)
+	require.Equal(t, "ETH", res.Networks[0].NativeCurrency)
+
+	require.Equal(t, int64(1), res.Networks[1].Id)
+	require.Equal(t, "Polygon", res.Networks[1].Name)
+	require.Equal(t, "MATIC", res.Networks[1].NativeCurrency)
+}

--- a/types.go
+++ b/types.go
@@ -71,9 +71,6 @@ type CryptoDetails struct {
 	Txid    string `json:"txid"`
 }
 
-type DecimalFloat struct {
-}
-
 type DetailFields struct {
 	CryptoDetails CryptoDetails `json:"crypto_details"`
 	TradeDetails  TradeDetails  `json:"trade_details"`
@@ -533,12 +530,12 @@ const (
 )
 
 type Transaction struct {
-	AccountId      string       `json:"account_id"`
-	Available      DecimalFloat `json:"available"`
-	AvailableDelta DecimalFloat `json:"available_delta"`
-	Balance        DecimalFloat `json:"balance"`
-	BalanceDelta   DecimalFloat `json:"balance_delta"`
-	Currency       string       `json:"currency"`
+	AccountId      string          `json:"account_id"`
+	Available      decimal.Decimal `json:"available"`
+	AvailableDelta decimal.Decimal `json:"available_delta"`
+	Balance        decimal.Decimal `json:"balance"`
+	BalanceDelta   decimal.Decimal `json:"balance_delta"`
+	Currency       string          `json:"currency"`
 
 	// Human-readable description of the transaction.
 	Description  string       `json:"description"`

--- a/types.go
+++ b/types.go
@@ -71,6 +71,9 @@ type CryptoDetails struct {
 	Txid    string `json:"txid"`
 }
 
+type DecimalFloat struct {
+}
+
 type DetailFields struct {
 	CryptoDetails CryptoDetails `json:"crypto_details"`
 	TradeDetails  TradeDetails  `json:"trade_details"`
@@ -104,6 +107,10 @@ type FundsMove struct {
 	// balance.<br>
 	// <code>FAILED</code> The move has failed. There could be many reasons for this but the most likely is that the
 	// debit account doesn't have enough available funds to move.<br>
+	// CREATED MoveStatusCreated
+	// MOVING MoveStatusMoving
+	// SUCCESSFUL MoveStatusSuccessful
+	// FAILED MoveStatusFailed
 	Status Status `json:"status"`
 
 	// Unix time the move was last updated, in milliseconds
@@ -118,6 +125,21 @@ const (
 	KindInterest Kind = "INTEREST"
 	KindTransfer Kind = "TRANSFER"
 )
+
+type LinkedUser struct {
+	// Time of the linked user provided permission (Unix milliseconds)
+	CreatedAt int64 `json:"created_at"`
+
+	// A reference to the linked user.
+	Label string `json:"label"`
+
+	// Permissions A list of permissions granted to the API client over the linked user.
+	// These permissions are enforced when acting on behalf of the linked user.
+	Permissions []string `json:"permissions"`
+
+	// The user ID the API client can act on behalf of
+	UserId string `json:"user_id"`
+}
 
 type MarketInfo struct {
 	// Base currency code
@@ -158,10 +180,17 @@ type MarketInfo struct {
 	// post-only.<br>
 	// <code>Unknown</code> Trading status is unknown. This could indicate a temporary error
 	// on the market and should resolve shortly.
+	// POST_ONLY MarketStatusPostOnly
+	// ACTIVE MarketStatusActive
+	// SUSPENDED MarketStatusSuspended
+	// UNKNOWN MarketStatusUnknown
 	TradingStatus TradingStatus `json:"trading_status"`
 
 	// Volume decimal places
 	VolumeScale int64 `json:"volume_scale"`
+}
+
+type Network struct {
 }
 
 type Order struct {
@@ -303,6 +332,8 @@ type OrderV2 struct {
 	// The intention of the order, whether to buy or sell funds in the market.
 	//
 	// You can use this to determine the flow of funds in the order.
+	// BUY OrderSideBuy
+	// SELL OrderSideSell
 	Side Side `json:"side"`
 
 	// The current state of the order
@@ -313,9 +344,14 @@ type OrderV2 struct {
 	// have taken place but the order is not filled yet.<br>
 	// <code>COMPLETE</code> The order is no longer in the order book. It has
 	// been settled/filled or has been cancelled.
+	// AWAITING OrderStatusAwaiting
+	// PENDING OrderStatusPending
+	// COMPLETE OrderStatusComplete
 	Status Status `json:"status"`
 
 	// Direction to trigger the order
+	// ABOVE StopDirectionAbove
+	// BELOW StopDirectionBelow
 	StopDirection StopDirection `json:"stop_direction"`
 
 	// Price to trigger the order
@@ -330,6 +366,9 @@ type OrderV2 struct {
 	TimeInForce string `json:"time_in_force"`
 
 	// The order type
+	// LIMIT OrderTypeLimit
+	// MARKET OrderTypeMarket
+	// STOP_LIMIT OrderTypeStopLimit
 	Type Type `json:"type"`
 }
 
@@ -348,6 +387,16 @@ type PublicTrade struct {
 
 	// Amount of assets traded
 	Volume decimal.Decimal `json:"volume"`
+}
+
+type SendNetwork struct {
+	Id Network `json:"id"`
+
+	// The network name
+	Name string `json:"name"`
+
+	// The native currency for the network
+	NativeCurrency string `json:"native_currency"`
 }
 
 type Side string
@@ -484,20 +533,12 @@ const (
 )
 
 type Transaction struct {
-	AccountId string `json:"account_id"`
-
-	// Amount available
-	Available decimal.Decimal `json:"available"`
-
-	// Change in amount available
-	AvailableDelta decimal.Decimal `json:"available_delta"`
-
-	// Account balance
-	Balance decimal.Decimal `json:"balance"`
-
-	// Change in balance
-	BalanceDelta decimal.Decimal `json:"balance_delta"`
-	Currency     string          `json:"currency"`
+	AccountId      string       `json:"account_id"`
+	Available      DecimalFloat `json:"available"`
+	AvailableDelta DecimalFloat `json:"available_delta"`
+	Balance        DecimalFloat `json:"balance"`
+	BalanceDelta   DecimalFloat `json:"balance_delta"`
+	Currency       string       `json:"currency"`
 
 	// Human-readable description of the transaction.
 	Description  string       `json:"description"`
@@ -512,6 +553,10 @@ type Transaction struct {
 	// <code>FEE</code> when transaction is towards Luno fees<br>
 	// <code>TRANSFER</code> when the transaction is a one way flow of funds, e.g. a deposit or crypto send<br>
 	// <code>EXCHANGE</code> when the transaction is part of a two way exchange, e.g. a trade or instant buy
+	// FEE KindFee  KindFee when transaction is towards Luno fees
+	// TRANSFER KindTransfer  KindTransfer when the transaction is a one way flow of funds
+	// EXCHANGE KindExchange  KindExchange when the transaction is part of a two way exchange
+	// INTEREST KindInterest  KindInterest when the transaction is an interest payment.
 	Kind Kind `json:"kind"`
 
 	// A unique reference for the transaction this statement entry relates to.

--- a/types.go
+++ b/types.go
@@ -104,10 +104,10 @@ type FundsMove struct {
 	// balance.<br>
 	// <code>FAILED</code> The move has failed. There could be many reasons for this but the most likely is that the
 	// debit account doesn't have enough available funds to move.<br>
-	// CREATED MoveStatusCreated
-	// MOVING MoveStatusMoving
-	// SUCCESSFUL MoveStatusSuccessful
-	// FAILED MoveStatusFailed
+	// CREATED StatusCreated
+	// MOVING StatusMoving
+	// SUCCESSFUL StatusSuccessful
+	// FAILED StatusFailed
 	Status Status `json:"status"`
 
 	// Unix time the move was last updated, in milliseconds
@@ -177,17 +177,14 @@ type MarketInfo struct {
 	// post-only.<br>
 	// <code>Unknown</code> Trading status is unknown. This could indicate a temporary error
 	// on the market and should resolve shortly.
-	// POST_ONLY MarketStatusPostOnly
-	// ACTIVE MarketStatusActive
-	// SUSPENDED MarketStatusSuspended
-	// UNKNOWN MarketStatusUnknown
+	// POST_ONLY TradingStatusPost_only
+	// ACTIVE TradingStatusActive
+	// SUSPENDED TradingStatusSuspended
+	// UNKNOWN TradingStatusUnknown
 	TradingStatus TradingStatus `json:"trading_status"`
 
 	// Volume decimal places
 	VolumeScale int64 `json:"volume_scale"`
-}
-
-type Network struct {
 }
 
 type Order struct {
@@ -329,8 +326,8 @@ type OrderV2 struct {
 	// The intention of the order, whether to buy or sell funds in the market.
 	//
 	// You can use this to determine the flow of funds in the order.
-	// BUY OrderSideBuy
-	// SELL OrderSideSell
+	// BUY SideBuy
+	// SELL SideSell
 	Side Side `json:"side"`
 
 	// The current state of the order
@@ -341,9 +338,9 @@ type OrderV2 struct {
 	// have taken place but the order is not filled yet.<br>
 	// <code>COMPLETE</code> The order is no longer in the order book. It has
 	// been settled/filled or has been cancelled.
-	// AWAITING OrderStatusAwaiting
-	// PENDING OrderStatusPending
-	// COMPLETE OrderStatusComplete
+	// AWAITING StatusAwaiting
+	// PENDING StatusPending
+	// COMPLETE StatusComplete
 	Status Status `json:"status"`
 
 	// Direction to trigger the order
@@ -363,9 +360,9 @@ type OrderV2 struct {
 	TimeInForce string `json:"time_in_force"`
 
 	// The order type
-	// LIMIT OrderTypeLimit
-	// MARKET OrderTypeMarket
-	// STOP_LIMIT OrderTypeStopLimit
+	// LIMIT TypeLimit
+	// MARKET TypeMarket
+	// STOP_LIMIT TypeStop_limit
 	Type Type `json:"type"`
 }
 
@@ -387,7 +384,7 @@ type PublicTrade struct {
 }
 
 type SendNetwork struct {
-	Id Network `json:"id"`
+	Id int64 `json:"id"`
 
 	// The network name
 	Name string `json:"name"`
@@ -549,11 +546,12 @@ type Transaction struct {
 	// Kinds explained:<br>
 	// <code>FEE</code> when transaction is towards Luno fees<br>
 	// <code>TRANSFER</code> when the transaction is a one way flow of funds, e.g. a deposit or crypto send<br>
-	// <code>EXCHANGE</code> when the transaction is part of a two way exchange, e.g. a trade or instant buy
-	// FEE KindFee  KindFee when transaction is towards Luno fees
-	// TRANSFER KindTransfer  KindTransfer when the transaction is a one way flow of funds
-	// EXCHANGE KindExchange  KindExchange when the transaction is part of a two way exchange
-	// INTEREST KindInterest  KindInterest when the transaction is an interest payment.
+	// <code>EXCHANGE</code> when the transaction is part of a two way exchange, e.g. a trade or instant buy<br>
+	// <code>INTEREST</code> when the transaction is an interest payment
+	// FEE KindFee
+	// TRANSFER KindTransfer
+	// EXCHANGE KindExchange
+	// INTEREST KindInterest
 	Kind Kind `json:"kind"`
 
 	// A unique reference for the transaction this statement entry relates to.


### PR DESCRIPTION
## Summary
- Regenerated `api.go` and `types.go` from the latest public API swagger spec using `sdkgen`.
- Adds the new `Convert` endpoint (`POST /api/exchange/1/convert`).
- Pulls in other accumulated additions: `Linked` and `SendNetworks` endpoints; `LinkedUser`, `SendNetwork`, `Network`, and `DecimalFloat` types.
- Updates existing endpoints: `Network` field on `CreateFundingAddress`/`Send`/`SendFee`; `SourceAccountId` on `CreateWithdrawal`; split `MakerFeeBuy`/`MakerFeeSell` and `TakerFeeBuy`/`TakerFeeSell` on `GetFeeInfo`.

## Note on spec hygiene
`sdkgen` failed on the live spec because `LinkedUser.permissions` had `items: {}` (empty schema) and emitted a Go field with no element type. To unblock this PR I patched my local copy of `services/fe/publicapi/swagger/swagger.json` to set the items type to `string`, matching the generated `Permissions []string`. A real fix in core (likely an explicit `swagger:type` annotation on `LinkedUser.Permissions []PermissionsEnum`) will need a separate PR — until that lands, the spec patch needs to be reapplied each regen.

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` passes locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Currency conversion endpoint, account linking, and send-networks discovery
  * Network selection for funding, funding retrieval and sends; source-account selection for withdrawals
  * Fee info expanded to show explicit maker/taker buy/sell rates

* **Documentation**
  * Status/side/type fields clarified with enum-style descriptors

* **Tests**
  * Added unit tests covering conversion, linked users and send-networks APIs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->